### PR TITLE
feat: add header config

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 VITE_API_BASE_URL=https://coipekj2sl.execute-api.ap-northeast-1.amazonaws.com/dev
 VITE_CHAT_API_URL=https://67hnjuna66.execute-api.ap-northeast-1.amazonaws.com/prd-1
 VITE_ACCENT_COLOR=orange
+VITE_SHOW_NAVIGATION_HEADER=true

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,16 +1,18 @@
 import { useEffect, useRef } from 'react';
 import { UserCircle, Loader2 } from 'lucide-react';
 import { useLocale } from '../contexts/LocaleContext';
+import NavigationHeader from '../components/common/NavigationHeader';
 import ChatMessage from '../components/ui/ChatMessage';
 import ChatInput from '../components/ui/ChatInput';
 import QuickReply, { QuickReplyOption } from '../components/ui/QuickReply';
 import { useChat } from '../hooks/useChat';
 import { useTheme } from '../hooks/useTheme';
-import { getAccentColor } from '../services/config';
+import { getAccentColor, getShowNavigationHeader } from '../services/config';
 
 function MainPage() {
   const { t, isLoading } = useLocale();
   const accentColor = getAccentColor();
+  const showNavigationHeader = getShowNavigationHeader();
   const { colors } = useTheme();
   const isInitialized = useRef(false);
 
@@ -64,6 +66,10 @@ function MainPage() {
 
   return (
     <div className="h-screen flex flex-col bg-white overflow-hidden">
+      {showNavigationHeader && (
+        <NavigationHeader title={t('common.home')} accentColor={accentColor} />
+      )}
+      
       <div className={`bg-gradient-to-r ${colors.gradient.from} ${colors.gradient.to} flex-shrink-0`}>
         <div className="max-w-3xl mx-auto px-4 py-3">
           <div className="flex items-center gap-4">

--- a/src/services/config/index.ts
+++ b/src/services/config/index.ts
@@ -31,11 +31,23 @@ export const getAccentColor = () => {
   return accentColor as 'orange' | 'blue' | 'green' | 'purple';
 };
 
+export const getShowNavigationHeader = () => {
+  const showHeader = import.meta.env.VITE_SHOW_NAVIGATION_HEADER;
+  
+  // 문자열 'true'를 boolean으로 변환, 기본값은 true
+  if (showHeader === 'false') {
+    return false;
+  }
+  
+  return true;
+};
+
 export const getAppConfig = () => {
   return {
     apiUrl: getApiUrl(),
     chatApiUrl: getChatApiUrl(),
     accentColor: getAccentColor(),
+    showNavigationHeader: getShowNavigationHeader(),
     environment: import.meta.env.MODE,
     isDevelopment: import.meta.env.DEV,
     isProduction: import.meta.env.PROD,


### PR DESCRIPTION
This pull request introduces a feature to conditionally display a navigation header on the `MainPage` based on a new environment variable. It includes updates to the environment configuration, the `MainPage` component, and the configuration service.

### Feature: Conditional Navigation Header

* **Environment Variable Addition**: Added `VITE_SHOW_NAVIGATION_HEADER` to the `.env` file, enabling control over the visibility of the navigation header.

* **Configuration Service Update**: Added `getShowNavigationHeader` function in `src/services/config/index.ts` to retrieve and parse the `VITE_SHOW_NAVIGATION_HEADER` environment variable. Default behavior is set to `true` unless explicitly set to `'false'`. Updated `getAppConfig` to include the new configuration.

* **MainPage Component Update**: 
  - Imported `NavigationHeader` and the new `getShowNavigationHeader` function.
  - Integrated logic to conditionally render the `NavigationHeader` component based on the `showNavigationHeader` flag. The header displays the title "Home" with an accent color.