### PR TITLE
feat: implement menu modal and improve architecture

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -29,6 +29,18 @@ const preview: Preview = {
     a11y: {
       disable: true,
     },
+    options: {
+      storySort: {
+        order: [
+          'Atoms',
+          'Molecules', 
+          'Organisms',
+          'Templates',
+          'Pages',
+          '*'
+        ],
+      },
+    },
   },
   tags: ['autodocs'],
 };

--- a/src/components/molecules/TypingIndicator/TypingIndicator.stories.tsx
+++ b/src/components/molecules/TypingIndicator/TypingIndicator.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { TypingIndicator } from './TypingIndicator';
+
+const meta: Meta<typeof TypingIndicator> = {
+  title: 'Molecules/TypingIndicator',
+  component: TypingIndicator,
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    accentColor: {
+      control: { type: 'select' },
+      options: ['orange', 'blue', 'green', 'purple', 'red'],
+    },
+    showLoader: {
+      control: 'boolean',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof TypingIndicator>;
+
+export const Default: Story = {
+  args: {
+    accentColor: 'orange',
+    showLoader: true,
+  },
+};
+
+export const WithoutLoader: Story = {
+  args: {
+    accentColor: 'orange',
+    showLoader: false,
+  },
+};
+
+export const BlueTheme: Story = {
+  args: {
+    accentColor: 'blue',
+    showLoader: true,
+  },
+};
+
+export const GreenTheme: Story = {
+  args: {
+    accentColor: 'green',
+    showLoader: true,
+  },
+};

--- a/src/components/molecules/TypingIndicator/TypingIndicator.tsx
+++ b/src/components/molecules/TypingIndicator/TypingIndicator.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Loader2 } from 'lucide-react';
+import { getColorClasses, AccentColor } from '../../../shared/config/theme.config';
+
+interface TypingIndicatorProps {
+  accentColor?: AccentColor;
+  showLoader?: boolean;
+  className?: string;
+}
+
+export function TypingIndicator({ 
+  accentColor = 'orange',
+  showLoader = true,
+  className = ''
+}: TypingIndicatorProps) {
+  const colors = getColorClasses(accentColor);
+  
+  return (
+    <div className={`flex items-start gap-3 ${className}`}>
+      {showLoader && (
+        <div className={`${colors.background} text-white p-2 rounded-full flex-shrink-0`}>
+          <Loader2 className="w-4 h-4 animate-spin" />
+        </div>
+      )}
+      <div className={`${colors.bgLight} p-3 rounded-2xl rounded-bl-sm`}>
+        <div className="flex items-center gap-1">
+          <div 
+            className={`w-2 h-2 ${colors.background} rounded-full animate-bounce`} 
+            style={{ animationDelay: '0ms' }}
+          />
+          <div 
+            className={`w-2 h-2 ${colors.background} rounded-full animate-bounce`} 
+            style={{ animationDelay: '150ms' }}
+          />
+          <div 
+            className={`w-2 h-2 ${colors.background} rounded-full animate-bounce`} 
+            style={{ animationDelay: '300ms' }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/molecules/TypingIndicator/index.ts
+++ b/src/components/molecules/TypingIndicator/index.ts
@@ -1,0 +1,1 @@
+export { TypingIndicator } from './TypingIndicator';

--- a/src/components/organisms/ChatInput/ChatInput.tsx
+++ b/src/components/organisms/ChatInput/ChatInput.tsx
@@ -1,10 +1,14 @@
-import React from 'react';
-import { getColorClasses, AccentColor } from '../../../shared/config/theme.config';
+import React, { useState, useEffect } from 'react';
+import { getColorClasses } from '../../../shared/config/theme.config';
 import { getAccentColor } from '../../../shared/config/app.config';
-import { CategoryIcon, SendIcon } from '../../../assets/icons';
+import { SendIcon, CategoryIcon } from '../../../assets/icons';
 import { useLocale } from '../../../contexts/LocaleContext';
 import { Button } from '../../atoms/Button';
 import { InputField } from '../../molecules/InputField';
+import { MenuModal } from '../MenuModal';
+import { MenuService } from '../../../services/menuService';
+import { useKeyboardState } from '../../../hooks/useKeyboardState';
+import type { MenuConfig, MenuItem } from '../../../shared/config/menuConfig';
 
 interface ChatInputProps {
   value: string;
@@ -12,6 +16,8 @@ interface ChatInputProps {
   onSend: () => void;
   disabled?: boolean;
   placeholder?: string;
+  clientId?: string;
+  onMenuItemClick?: (item: MenuItem) => void;
 }
 
 export function ChatInput({ 
@@ -19,11 +25,24 @@ export function ChatInput({
   onChange, 
   onSend, 
   disabled = false,
-  placeholder 
+  placeholder,
+  clientId = 'default',
+  onMenuItemClick
 }: ChatInputProps) {
   const { t } = useLocale();
   const accentColor = getAccentColor();
   const colors = getColorClasses(accentColor);
+  
+  // 메뉴 모달 상태 관리
+  const [isMenuModalOpen, setIsMenuModalOpen] = useState(false);
+  const [menuConfig, setMenuConfig] = useState<MenuConfig | null>(null);
+  const isKeyboardOpen = useKeyboardState();
+
+  // 고객사별 메뉴 설정 가져오기
+  useEffect(() => {
+    const config = MenuService.getMenuConfig(clientId);
+    setMenuConfig(config);
+  }, [clientId]);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && !e.shiftKey) {
@@ -38,14 +57,40 @@ export function ChatInput({
     }
   };
 
+  const handleMenuClick = () => {
+    // 키보드가 열려있으면 키보드가 닫힐 때까지 대기
+    if (isKeyboardOpen) {
+      // input에서 포커스 제거
+      const activeElement = document.activeElement as HTMLElement;
+      if (activeElement && (activeElement.tagName === 'INPUT' || activeElement.tagName === 'TEXTAREA')) {
+        activeElement.blur();
+      }
+      
+      // 키보드가 닫힌 후 메뉴 모달 열기
+      setTimeout(() => {
+        setIsMenuModalOpen(true);
+      }, 300);
+    } else {
+      setIsMenuModalOpen(true);
+    }
+  };
+
+  const handleMenuItemClick = (item: MenuItem) => {
+    if (onMenuItemClick) {
+      onMenuItemClick(item);
+    }
+    setIsMenuModalOpen(false);
+  };
+
   return (
     <div className="w-full bg-white flex justify-center items-end px-2 sm:px-4 py-4 gap-2 sm:gap-3" style={{ paddingBottom: 'max(1rem, env(safe-area-inset-bottom))' }}>
-      {/* Category Button */}
+      {/* Menu Button */}
       <Button
+        onClick={handleMenuClick}
         className={`w-8 h-8 sm:w-[35px] sm:h-[35px] flex justify-center items-center flex-shrink-0 transition-colors ${colors.backgroundHover} hover:text-white group`}
-        aria-label="카테고리"
+        aria-label="메뉴"
       >
-        <CategoryIcon className={`w-7 h-7 ${colors.textBlack} group-hover:text-white`} />
+        <CategoryIcon className={`w-6 h-6 ${colors.textBlack} group-hover:text-white`} />
       </Button>
       
       {/* Input Field */}
@@ -75,6 +120,17 @@ export function ChatInput({
             : 'text-gray-400'
         }`} />
       </Button>
+
+      {/* Menu Modal */}
+      {menuConfig && (
+        <MenuModal
+          isOpen={isMenuModalOpen}
+          onClose={() => setIsMenuModalOpen(false)}
+          menuConfig={menuConfig}
+          accentColor={accentColor}
+          onMenuItemClick={handleMenuItemClick}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/organisms/MenuModal/MenuModal.stories.tsx
+++ b/src/components/organisms/MenuModal/MenuModal.stories.tsx
@@ -1,0 +1,191 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { MenuModal } from './MenuModal';
+import { defaultMenuConfig } from '../../../shared/config/menuConfig';
+import type { MenuConfig } from '../../../shared/config/menuConfig';
+
+const meta: Meta<typeof MenuModal> = {
+  title: 'Organisms/MenuModal',
+  component: MenuModal,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  argTypes: {
+    isOpen: {
+      control: 'boolean',
+    },
+    accentColor: {
+      control: { type: 'select' },
+      options: ['orange', 'blue', 'green', 'purple', 'red'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof MenuModal>;
+
+// 3개 메뉴 + CTA
+const threeItemsConfig: MenuConfig = {
+  items: [
+    {
+      id: 'ai-faq',
+      icon: 'MessageCircle',
+      label: 'AI FAQ',
+      action: 'navigate',
+      url: '/faq'
+    },
+    {
+      id: 'request-materials',
+      icon: 'FileText',
+      label: '資料請求',
+      action: 'navigate',
+      url: '/request-materials'
+    },
+    {
+      id: 'ai-consultation',
+      icon: 'Phone',
+      label: 'AI電話相談',
+      action: 'navigate',
+      url: '/consultation'
+    }
+  ],
+  cta: {
+    label: '無料体験に応募する',
+    action: 'navigate',
+    url: '/free-trial'
+  }
+};
+
+// 3개 메뉴만 (CTA 없음)
+const threeItemsNoCTAConfig: MenuConfig = {
+  items: threeItemsConfig.items
+};
+
+// 4개 메뉴만 (CTA 없음)
+const fourItemsConfig: MenuConfig = {
+  items: [
+    ...threeItemsConfig.items,
+    {
+      id: 'support',
+      icon: 'HelpCircle',
+      label: 'サポート',
+      action: 'navigate',
+      url: '/support'
+    }
+  ]
+};
+
+// 6개 메뉴만 (CTA 없음)
+const sixItemsConfig: MenuConfig = {
+  items: [
+    ...fourItemsConfig.items,
+    {
+      id: 'news',
+      icon: 'Newspaper',
+      label: 'ニュース',
+      action: 'navigate',
+      url: '/news'
+    },
+    {
+      id: 'events',
+      icon: 'Calendar',
+      label: 'イベント',
+      action: 'navigate',
+      url: '/events'
+    }
+  ]
+};
+
+export const ThreeItemsWithCTA: Story = {
+  args: {
+    isOpen: true,
+    menuConfig: threeItemsConfig,
+    accentColor: 'orange',
+    onClose: () => console.log('Modal closed'),
+    onMenuItemClick: (item) => console.log('Menu item clicked:', item),
+  },
+};
+
+export const ThreeItemsNoCTA: Story = {
+  args: {
+    isOpen: true,
+    menuConfig: threeItemsNoCTAConfig,
+    accentColor: 'orange',
+    onClose: () => console.log('Modal closed'),
+    onMenuItemClick: (item) => console.log('Menu item clicked:', item),
+  },
+};
+
+export const FourItems: Story = {
+  args: {
+    isOpen: true,
+    menuConfig: fourItemsConfig,
+    accentColor: 'orange',
+    onClose: () => console.log('Modal closed'),
+    onMenuItemClick: (item) => console.log('Menu item clicked:', item),
+  },
+};
+
+export const SixItems: Story = {
+  args: {
+    isOpen: true,
+    menuConfig: sixItemsConfig,
+    accentColor: 'orange',
+    onClose: () => console.log('Modal closed'),
+    onMenuItemClick: (item) => console.log('Menu item clicked:', item),
+  },
+};
+
+// 일부 메뉴가 비활성화된 상태
+const threeItemsWithDisabledConfig: MenuConfig = {
+  items: [
+    {
+      id: 'ai-faq',
+      icon: 'MessageCircle',
+      label: 'AI FAQ',
+      action: 'navigate',
+      url: '/faq',
+      disabled: false
+    },
+    {
+      id: 'request-materials',
+      icon: 'FileText',
+      label: '資料請求',
+      action: 'navigate',
+      url: '/request-materials',
+      disabled: true  // 비활성화
+    },
+    {
+      id: 'ai-consultation',
+      icon: 'Phone',
+      label: 'AI電話相談',
+      action: 'navigate',
+      url: '/consultation',
+      disabled: false
+    }
+  ],
+  cta: {
+    label: '無料体験に応募する',
+    action: 'navigate',
+    url: '/free-trial'
+  }
+};
+
+export const WithDisabledItems: Story = {
+  args: {
+    isOpen: true,
+    menuConfig: threeItemsWithDisabledConfig,
+    accentColor: 'orange',
+    onClose: () => console.log('Modal closed'),
+    onMenuItemClick: (item) => console.log('Menu item clicked:', item),
+  },
+};
+
+export const Closed: Story = {
+  args: {
+    isOpen: false,
+    menuConfig: threeItemsConfig,
+    accentColor: 'orange',
+    onClose: () => console.log('Modal closed'),
+    onMenuItemClick: (item) => console.log('Menu item clicked:', item),
+  },
+};

--- a/src/components/organisms/MenuModal/MenuModal.tsx
+++ b/src/components/organisms/MenuModal/MenuModal.tsx
@@ -1,0 +1,190 @@
+import React, { useEffect, useRef } from 'react';
+import { X, MessageCircle, FileText, Phone } from 'lucide-react';
+import { Icon } from '../../atoms/Icon/Icon';
+import { useLocale } from '../../../contexts/LocaleContext';
+import type { MenuConfig, MenuItem } from '../../../shared/config/menuConfig';
+import type { AccentColor } from '../../../shared/config/theme.config';
+import { getColorClasses } from '../../../shared/config/theme.config';
+
+interface MenuModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  menuConfig: MenuConfig;
+  accentColor?: AccentColor;
+  onMenuItemClick?: (item: MenuItem) => void;
+}
+
+// 아이콘 매핑
+const iconMap: Record<string, any> = {
+  MessageCircle,
+  FileText,
+  Phone,
+};
+
+export function MenuModal({
+  isOpen,
+  onClose,
+  menuConfig,
+  accentColor = 'orange',
+  onMenuItemClick
+}: MenuModalProps) {
+  const { t } = useLocale();
+  const modalRef = useRef<HTMLDivElement>(null);
+  const colors = getColorClasses(accentColor);
+
+  // ESC 키로 모달 닫기
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleEscKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleEscKey);
+
+    return () => {
+      document.removeEventListener('keydown', handleEscKey);
+    };
+  }, [isOpen, onClose]);
+
+  // 모달이 열릴 때 body 스크롤 방지
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const handleMenuItemClick = (item: MenuItem) => {
+    if (item.disabled) return;
+    
+    if (onMenuItemClick) {
+      onMenuItemClick(item);
+    }
+    
+    // 메뉴 아이템 클릭 후 모달 닫기
+    onClose();
+  };
+
+  return (
+    <div 
+      className="fixed inset-0 z-50 bg-transparent flex items-end justify-center"
+      onClick={onClose}
+    >
+      <div
+        ref={modalRef}
+        className={`
+          ${colors.bgLight} shadow-xl
+          transform transition-transform duration-300 ease-out
+          ${isOpen ? 'translate-y-0' : 'translate-y-full'}
+          w-full max-w-lg mx-auto
+          sm:max-w-md sm:mb-4
+        `}
+        style={{ paddingBottom: 'max(1rem, env(safe-area-inset-bottom))' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* 헤더 */}
+        <div className="flex items-center justify-end px-4 py-2">
+          <button
+            onClick={onClose}
+            className="p-2 -m-2 text-gray-500 hover:text-gray-700 transition-colors"
+            aria-label={t('common.close')}
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* 메뉴 아이템들 */}
+        <div className="px-4 pb-4">
+          {/* 메뉴 아이템 그리드 - 아이템 개수에 따라 레이아웃 결정 */}
+          <div className={`
+            grid gap-3 mb-4
+            ${menuConfig.items.length === 3 ? 'grid-cols-3' : 
+              menuConfig.items.length === 4 ? 'grid-cols-2' : 
+              menuConfig.items.length === 6 ? 'grid-cols-3 w-full' :
+              'grid-cols-3'
+            }
+          `}>
+            {menuConfig.items.map((item) => (
+              <button
+                key={item.id}
+                onClick={() => handleMenuItemClick(item)}
+                disabled={item.disabled}
+                className={`
+                  flex items-center justify-center
+                  ${menuConfig.items.length === 4
+                    ? 'gap-3 rounded-[3px] p-4 min-h-[80px]'
+                    : 'flex-col gap-[3px] flex-1 self-stretch rounded-[3px]'
+                  }
+                  ${item.disabled 
+                    ? 'bg-white border border-gray-200 opacity-50 cursor-not-allowed' 
+                    : 'bg-white border border-gray-200 hover:bg-gray-50 active:bg-gray-100 transition-colors cursor-pointer'
+                  }
+                `}
+                style={item.disabled && menuConfig.items.length !== 4 ? {
+                  padding: '25px 36px'
+                } : menuConfig.items.length !== 4 ? {
+                  padding: '25px 36px'
+                } : undefined}
+              >
+                <Icon
+                  config={{
+                    type: 'lucide',
+                    value: item.icon,
+                    fallback: iconMap[item.icon] || MessageCircle
+                  }}
+                  className={`w-6 h-6 ${colors.text}`}
+                />
+                <span className={`text-xs font-medium ${colors.text} text-center leading-tight`}>
+                  {item.label}
+                </span>
+              </button>
+            ))}
+          </div>
+
+          {/* CTA 버튼 */}
+          {menuConfig.cta && (
+            <button
+              onClick={() => {
+                if (onMenuItemClick) {
+                  onMenuItemClick({
+                    id: 'cta',
+                    icon: 'Star',
+                    label: menuConfig.cta.label,
+                    action: menuConfig.cta.action,
+                    url: menuConfig.cta.url
+                  });
+                }
+                onClose();
+              }}
+              className={`
+                w-full px-4 py-4 rounded-lg font-semibold text-white
+                ${colors.background} hover:opacity-90 transition-opacity
+                flex items-center justify-center gap-2
+              `}
+            >
+              <Icon
+                config={{
+                  type: 'lucide',
+                  value: 'Info',
+                  fallback: MessageCircle
+                }}
+                className="w-5 h-5 text-white"
+              />
+              <span>{menuConfig.cta.label}</span>
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/organisms/MenuModal/index.ts
+++ b/src/components/organisms/MenuModal/index.ts
@@ -1,0 +1,1 @@
+export { MenuModal } from './MenuModal';

--- a/src/components/organisms/NavigationHeader/MenuButton.tsx
+++ b/src/components/organisms/NavigationHeader/MenuButton.tsx
@@ -1,0 +1,78 @@
+import React, { useState, useEffect } from 'react';
+import { Menu } from 'lucide-react';
+import { MenuModal } from '../MenuModal';
+import { useKeyboardState } from '../../../hooks/useKeyboardState';
+import { MenuService } from '../../../services/menuService';
+import type { AccentColor } from '../../../shared/config/theme.config';
+import { getColorClasses } from '../../../shared/config/theme.config';
+import type { MenuItem, MenuConfig } from '../../../shared/config/menuConfig';
+import { useNavigate } from 'react-router-dom';
+
+interface MenuButtonProps {
+  clientId?: string;
+  accentColor?: AccentColor;
+}
+
+export function MenuButton({ clientId = 'default', accentColor = 'orange' }: MenuButtonProps) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [menuConfig, setMenuConfig] = useState<MenuConfig | null>(null);
+  const isKeyboardOpen = useKeyboardState();
+  const colors = getColorClasses(accentColor);
+  const navigate = useNavigate();
+  
+  // 고객사별 메뉴 설정 가져오기
+  useEffect(() => {
+    const config = MenuService.getMenuConfig(clientId);
+    setMenuConfig(config);
+  }, [clientId]);
+
+  const handleMenuClick = () => {
+    // 키보드가 열려있으면 키보드가 닫힐 때까지 대기
+    if (isKeyboardOpen) {
+      // input에서 포커스 제거
+      const activeElement = document.activeElement as HTMLElement;
+      if (activeElement && (activeElement.tagName === 'INPUT' || activeElement.tagName === 'TEXTAREA')) {
+        activeElement.blur();
+      }
+      
+      // 키보드가 닫힌 후 모달 열기
+      setTimeout(() => {
+        setIsModalOpen(true);
+      }, 300);
+    } else {
+      setIsModalOpen(true);
+    }
+  };
+
+  const handleMenuItemClick = (item: MenuItem) => {
+    console.log('Menu item clicked:', item);
+    
+    // 실제 네비게이션 처리
+    if (item.action === 'navigate' && item.url) {
+      navigate(item.url);
+    }
+    // 추가 액션 타입들은 여기에서 처리
+  };
+
+  return (
+    <>
+      <button
+        onClick={handleMenuClick}
+        className={`p-3 rounded-lg transition-all duration-200 ${colors.bgHover}`}
+        aria-label="메뉴 열기"
+      >
+        <Menu className="w-6 h-6" />
+      </button>
+
+      {menuConfig && (
+        <MenuModal
+          isOpen={isModalOpen}
+          onClose={() => setIsModalOpen(false)}
+          menuConfig={menuConfig}
+          accentColor={accentColor}
+          onMenuItemClick={handleMenuItemClick}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/organisms/TopQuestions/TopQuestions.stories.tsx
+++ b/src/components/organisms/TopQuestions/TopQuestions.stories.tsx
@@ -1,5 +1,35 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { TopQuestions } from './TopQuestions';
+import { fn } from '@storybook/test';
+
+// API 모킹을 위한 mock 데이터
+const mockQuestions = {
+  general: [
+    '서비스 이용 방법이 궁금해요',
+    '회원가입은 어떻게 하나요?',
+    '비밀번호를 잊어버렸어요'
+  ],
+  academic: [
+    '수강신청은 언제 시작하나요?',
+    '성적 확인은 어디서 하나요?',
+    '휴학 신청 절차가 궁금합니다'
+  ],
+  technical: [
+    '앱이 실행되지 않아요',
+    '로그인이 안 돼요',
+    '화면이 깨져서 보여요'
+  ],
+  payment: [
+    '결제 수단을 변경하고 싶어요',
+    '환불은 어떻게 받나요?',
+    '결제 내역을 확인하고 싶어요'
+  ],
+  default: [
+    '자주 묻는 질문 1',
+    '자주 묻는 질문 2',
+    '자주 묻는 질문 3'
+  ]
+};
 
 const meta: Meta<typeof TopQuestions> = {
   title: 'Organisms/TopQuestions',
@@ -10,6 +40,11 @@ const meta: Meta<typeof TopQuestions> = {
       description: {
         component: '특정 FAQ 카테고리의 상위 질문들을 표시하는 컴포넌트입니다. 뒤로가기 버튼과 질문 목록을 제공합니다.',
       },
+    },
+    msw: {
+      handlers: [
+        // API 모킹 핸들러
+      ],
     },
   },
   argTypes: {
@@ -50,39 +85,55 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    categoryId: 'general',
-    categoryTitle: '일반 문의',
+    categoryId: 'category1',
+    categoryTitle: '授業について',
     userId: 'user123',
   },
 };
 
-export const AcademicCategory: Story = {
+export const TeacherCategory: Story = {
   args: {
-    categoryId: 'academic',
-    categoryTitle: '학사 관련',
+    categoryId: 'category2',
+    categoryTitle: '講師について',
     userId: 'user123',
   },
 };
 
-export const TechnicalCategory: Story = {
+export const AchievementCategory: Story = {
   args: {
-    categoryId: 'technical',
-    categoryTitle: '기술 지원',
+    categoryId: 'category3',
+    categoryTitle: '塾の実績について',
+    userId: 'user123',
+  },
+};
+
+export const HomeworkCategory: Story = {
+  args: {
+    categoryId: 'category4',
+    categoryTitle: '宿題について',
+    userId: 'user123',
+  },
+};
+
+export const OtherCategory: Story = {
+  args: {
+    categoryId: 'other',
+    categoryTitle: 'その他',
     userId: 'user123',
   },
 };
 
 export const LongCategoryTitle: Story = {
   args: {
-    categoryId: 'long-title',
-    categoryTitle: '매우 긴 카테고리 제목을 가진 FAQ 섹션',
+    categoryId: 'category1',
+    categoryTitle: '非常に長いカテゴリタイトルを持つFAQセクション',
     userId: 'user123',
   },
 };
 
-export const ShortCategoryTitle: Story = {
+export const ShortTitle: Story = {
   args: {
-    categoryId: 'short',
+    categoryId: 'category2',
     categoryTitle: 'FAQ',
     userId: 'user123',
   },
@@ -90,72 +141,16 @@ export const ShortCategoryTitle: Story = {
 
 export const WithEmojiTitle: Story = {
   args: {
-    categoryId: 'emoji',
-    categoryTitle: '📚 학습 가이드',
-    userId: 'user123',
-  },
-};
-
-export const PaymentCategory: Story = {
-  args: {
-    categoryId: 'payment',
-    categoryTitle: '💳 결제 문의',
-    userId: 'user123',
-  },
-};
-
-export const AccountCategory: Story = {
-  args: {
-    categoryId: 'account',
-    categoryTitle: '👤 계정 관리',
-    userId: 'user123',
-  },
-};
-
-export const SystemCategory: Story = {
-  args: {
-    categoryId: 'system',
-    categoryTitle: '⚙️ 시스템 설정',
-    userId: 'user123',
-  },
-};
-
-export const CommunityCategory: Story = {
-  args: {
-    categoryId: 'community',
-    categoryTitle: '👥 커뮤니티',
-    userId: 'user123',
-  },
-};
-
-export const SecurityCategory: Story = {
-  args: {
-    categoryId: 'security',
-    categoryTitle: '🔒 보안 관련',
-    userId: 'user123',
-  },
-};
-
-export const MobileCategory: Story = {
-  args: {
-    categoryId: 'mobile',
-    categoryTitle: '📱 모바일 앱',
-    userId: 'user123',
-  },
-};
-
-export const FeedbackCategory: Story = {
-  args: {
-    categoryId: 'feedback',
-    categoryTitle: '💬 피드백 및 제안',
+    categoryId: 'category3',
+    categoryTitle: '📚 学習ガイド',
     userId: 'user123',
   },
 };
 
 export const WithCustomClass: Story = {
   args: {
-    categoryId: 'custom',
-    categoryTitle: '맞춤 스타일',
+    categoryId: 'category1',
+    categoryTitle: 'カスタムスタイル',
     userId: 'user123',
     className: 'bg-blue-50 border border-blue-200 rounded-lg',
   },

--- a/src/components/templates/ChatLayout/ChatLayout.tsx
+++ b/src/components/templates/ChatLayout/ChatLayout.tsx
@@ -1,40 +1,36 @@
 import React from 'react';
 
 interface ChatLayoutProps {
-  header: React.ReactNode;
-  messages: React.ReactNode;
+  header?: React.ReactNode;
+  children: React.ReactNode;
   input: React.ReactNode;
-  quickReplies?: React.ReactNode;
-  faqCategory?: React.ReactNode;
   className?: string;
+  showNavigationHeader?: boolean;
 }
 
 export function ChatLayout({
   header,
-  messages,
+  children,
   input,
-  quickReplies,
-  faqCategory,
-  className = ""
+  className = "",
+  showNavigationHeader = false
 }: ChatLayoutProps) {
   return (
-    <div className={`flex flex-col h-full ${className}`}>
-      {/* Header */}
-      {header}
+    <div className={`h-screen flex flex-col bg-white overflow-hidden ${className}`}>
+      {/* Navigation Header */}
+      {showNavigationHeader && header}
       
-      {/* Messages Area */}
-      <div className="flex-1 overflow-y-auto px-4 py-4">
-        {messages}
-        
-        {/* Quick Replies */}
-        {quickReplies}
-        
-        {/* FAQ Category */}
-        {faqCategory}
+      {/* Main Content Area */}
+      <div className="flex-1 flex flex-col bg-gray-50 min-h-0">
+        <div className="flex-1 overflow-hidden">
+          {children}
+        </div>
+
+        {/* Input Area */}
+        <div className="flex-shrink-0">
+          {input}
+        </div>
       </div>
-      
-      {/* Input Area */}
-      {input}
     </div>
   );
 }

--- a/src/hooks/useKeyboardState.ts
+++ b/src/hooks/useKeyboardState.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+
+export function useKeyboardState() {
+  const [isKeyboardOpen, setIsKeyboardOpen] = useState(false);
+
+  useEffect(() => {
+    // 모바일 환경에서 키보드 상태 감지
+    const handleResize = () => {
+      // 모바일 브라우저에서 키보드가 열리면 viewport 높이가 감소함
+      const threshold = 100; // 픽셀 단위 임계값
+      const isNowOpen = window.innerHeight < window.screen.height - threshold;
+      setIsKeyboardOpen(isNowOpen);
+    };
+
+    // 입력 필드 포커스 이벤트 감지
+    const handleFocusIn = (e: FocusEvent) => {
+      const target = e.target as HTMLElement;
+      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA') {
+        setIsKeyboardOpen(true);
+      }
+    };
+
+    const handleFocusOut = () => {
+      // 약간의 지연 후 키보드 닫힘 처리
+      setTimeout(() => {
+        setIsKeyboardOpen(false);
+      }, 100);
+    };
+
+    window.addEventListener('resize', handleResize);
+    document.addEventListener('focusin', handleFocusIn);
+    document.addEventListener('focusout', handleFocusOut);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      document.removeEventListener('focusin', handleFocusIn);
+      document.removeEventListener('focusout', handleFocusOut);
+    };
+  }, []);
+
+  return isKeyboardOpen;
+}

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,21 +1,21 @@
 import { useEffect, useRef, useState } from 'react';
 import { Loader2 } from 'lucide-react';
 import { useLocale } from '../contexts/LocaleContext';
+import { ChatLayout } from '../components/templates/ChatLayout';
 import { NavigationHeader } from '../components/organisms/NavigationHeader';
 import { ChatMessage } from '../components/organisms/ChatMessage';
 import { ChatInput } from '../components/organisms/ChatInput';
 import { QuickReply } from '../components/organisms/QuickReply';
 import { FAQCategory } from '../components/organisms/FAQCategory';
 import { TopQuestions } from '../components/organisms/TopQuestions';
+import { TypingIndicator } from '../components/molecules/TypingIndicator';
 import { useChat } from '../hooks/useChat';
-import { useTheme } from '../hooks/useTheme';
 import { getAccentColor, getShowNavigationHeader } from '../shared/config/app.config';
 
 function MainPage() {
   const { t, isLoading } = useLocale();
   const accentColor = getAccentColor();
   const showNavigationHeader = getShowNavigationHeader();
-  const { colors } = useTheme();
   const isInitialized = useRef(false);
   const [showFigmaQuickReply, setShowFigmaQuickReply] = useState(false);
   const [showFAQCategories, setShowFAQCategories] = useState(false);
@@ -156,11 +156,33 @@ function MainPage() {
     await handleSendMessage();
   };
 
+  const handleMenuItemClick = (item: any) => {
+    console.log('Menu item clicked:', item);
+    
+    // FAQ 메뉴 클릭 시 처리
+    if (item.id === 'ai-faq') {
+      // 1. 유저 메시지로 라벨 표시
+      addUserMessage(item.label, false);
+      
+      // 2. FAQ 카테고리를 위한 봇 메시지 타이핑
+      setTimeout(() => {
+        const whatWouldYouLikeToKnow = t('chat.faq.whatWouldYouLikeToKnow');
+        setWaitingForFAQCategories(true);
+        addTypingBotMessage(whatWouldYouLikeToKnow);
+      }, 100);
+    }
+    // 다른 메뉴 아이템들 처리
+    else if (item.action === 'navigate' && item.url) {
+      // 네비게이션 액션 처리 (추후 구현)
+      console.log('Navigate to:', item.url);
+    }
+  };
+
   if (isLoading) {
     return (
       <div className="h-screen flex items-center justify-center bg-white">
         <div className="flex items-center gap-2">
-          <Loader2 className={`w-6 h-6 animate-spin ${colors.text}`} />
+          <Loader2 className="w-6 h-6 animate-spin text-navi-orange-main" />
           <span className="text-gray-600">Loading...</span>
         </div>
       </div>
@@ -168,8 +190,9 @@ function MainPage() {
   }
 
   return (
-    <div className="h-screen flex flex-col bg-white overflow-hidden">
-      {showNavigationHeader && (
+    <ChatLayout
+      showNavigationHeader={showNavigationHeader}
+      header={
         <NavigationHeader 
           title={t('common.home')} 
           accentColor={accentColor}
@@ -181,110 +204,80 @@ function MainPage() {
             }
           }}
         />
-      )}
-      
-      {/* <div className={`bg-gradient-to-r ${colors.gradient.from} ${colors.gradient.to} flex-shrink-0`}>
-        <div className="max-w-3xl mx-auto px-4 py-3">
-          <div className="flex items-center gap-4">
-            <div className={`bg-white/80 backdrop-blur-sm p-2.5 rounded-full shadow-sm border ${colors.border}`}>
-              <UserCircle className={`w-4 h-4 ${colors.text}`} />
-            </div>
-            <div>
-              <h1 className="text-lg font-bold text-gray-900">
-                {t('chat.welcomeGreeting')}
-              </h1>
-            </div>
-          </div>
-        </div>
-      </div> */}
-
-      <div className="flex-1 flex flex-col bg-gray-50 min-h-0">
-        <div className="flex-1 overflow-hidden">
-          <div 
-            ref={chatContainerRef}
-            className="h-full overflow-y-auto pb-4"
-          >
-            <div className="max-w-3xl mx-auto px-4 py-6 space-y-4">
-              {messages.map((message, index) => (
-                <div key={message.id}>
-                  <ChatMessage message={message} />
-                  {/* 첫 번째 메시지 (봇의 인사) 다음에 QuickReply 표시 */}
-                  {index === 0 && message.type === 'bot' && showFigmaQuickReply && (
-                    <div className="mt-4">
-                      <QuickReply 
-                        onReplyClick={handleQuickReplyClick}
-                        onShowFAQCategories={handleShowFAQCategories}
-                        show={true}
-                        userId="Hyunse0001"
-                      />
-                    </div>
-                  )}
-                  {/* FAQ 카테고리를 해당 메시지 바로 다음에 표시 */}
-                  {message.content === t('chat.faq.whatWouldYouLikeToKnow') && message.type === 'bot' && showFAQCategories && (
-                    <div className="mt-4">
-                      <FAQCategory 
-                        onCategorySelect={handleFAQCategorySelect}
-                      />
-                    </div>
-                  )}
-                  {/* Top 질문을 해당 메시지 바로 다음에 표시 */}
-                  {selectedCategory && message.content === t('chat.faq.categorySelected', { category: t(selectedCategory.textKey) }) && message.type === 'bot' && showTopQuestions && (
-                    <div className="mt-4">
-                      <TopQuestions
-                        categoryId={selectedCategory.id}
-                        categoryTitle={t(selectedCategory.textKey)}
-                        onQuestionSelect={handleTopQuestionSelect}
-                        onBackToCategories={handleBackToCategories}
-                        userId="Hyunse0001"
-                        onDataLoaded={handleTopQuestionsDataLoaded}
-                      />
-                    </div>
-                  )}
-                </div>
-              ))}
-              
-              {currentlyTyping && (
-                <ChatMessage
-                  message={{
-                    id: 'typing',
-                    type: 'bot',
-                    content: currentlyTyping.message,
-                    timestamp: new Date()
-                  }}
-                  isTyping={true}
-                  onTypingComplete={completeTyping}
-                />
-              )}
-              
-              {isTyping && !currentlyTyping && (
-                <div className="flex items-start gap-3">
-                  <div className={`${colors.background} text-white p-2 rounded-full flex-shrink-0`}>
-                    <Loader2 className="w-4 h-4 animate-spin" />
-                  </div>
-                  <div className={`${colors.bgLight} p-3 rounded-2xl rounded-bl-sm`}>
-                    <div className="flex items-center gap-1">
-                      <div className={`w-2 h-2 ${colors.background} rounded-full animate-bounce`} style={{ animationDelay: '0ms' }}></div>
-                      <div className={`w-2 h-2 ${colors.background} rounded-full animate-bounce`} style={{ animationDelay: '150ms' }}></div>
-                      <div className={`w-2 h-2 ${colors.background} rounded-full animate-bounce`} style={{ animationDelay: '300ms' }}></div>
-                    </div>
-                  </div>
+      }
+      input={
+        <ChatInput
+          value={newMessage}
+          onChange={setNewMessage}
+          onSend={handleSendClick}
+          disabled={isTyping}
+          onMenuItemClick={handleMenuItemClick}
+        />
+      }
+    >
+      <div 
+        ref={chatContainerRef}
+        className="h-full overflow-y-auto pb-4"
+      >
+        <div className="max-w-3xl mx-auto px-4 py-6 space-y-4">
+          {messages.map((message, index) => (
+            <div key={message.id}>
+              <ChatMessage message={message} />
+              {/* 첫 번째 메시지 (봇의 인사) 다음에 QuickReply 표시 */}
+              {index === 0 && message.type === 'bot' && showFigmaQuickReply && (
+                <div className="mt-4">
+                  <QuickReply 
+                    onReplyClick={handleQuickReplyClick}
+                    onShowFAQCategories={handleShowFAQCategories}
+                    show={true}
+                    userId="Hyunse0001"
+                  />
                 </div>
               )}
-              <div ref={messagesEndRef} />
+              {/* FAQ 카테고리를 해당 메시지 바로 다음에 표시 */}
+              {message.content === t('chat.faq.whatWouldYouLikeToKnow') && message.type === 'bot' && showFAQCategories && (
+                <div className="mt-4">
+                  <FAQCategory 
+                    onCategorySelect={handleFAQCategorySelect}
+                  />
+                </div>
+              )}
+              {/* Top 질문을 해당 메시지 바로 다음에 표시 */}
+              {selectedCategory && message.content === t('chat.faq.categorySelected', { category: t(selectedCategory.textKey) }) && message.type === 'bot' && showTopQuestions && (
+                <div className="mt-4">
+                  <TopQuestions
+                    categoryId={selectedCategory.id}
+                    categoryTitle={t(selectedCategory.textKey)}
+                    onQuestionSelect={handleTopQuestionSelect}
+                    onBackToCategories={handleBackToCategories}
+                    userId="Hyunse0001"
+                    onDataLoaded={handleTopQuestionsDataLoaded}
+                  />
+                </div>
+              )}
             </div>
-          </div>
-        </div>
-
-        <div className="flex-shrink-0">
-          <ChatInput
-            value={newMessage}
-            onChange={setNewMessage}
-            onSend={handleSendClick}
-            disabled={isTyping}
-          />
+          ))}
+          
+          {currentlyTyping && (
+            <ChatMessage
+              message={{
+                id: 'typing',
+                type: 'bot',
+                content: currentlyTyping.message,
+                timestamp: new Date()
+              }}
+              isTyping={true}
+              onTypingComplete={completeTyping}
+            />
+          )}
+          
+          {isTyping && !currentlyTyping && (
+            <TypingIndicator accentColor={accentColor} />
+          )}
+          <div ref={messagesEndRef} />
         </div>
       </div>
-    </div>
+    </ChatLayout>
   );
 }
 

--- a/src/services/menuService.ts
+++ b/src/services/menuService.ts
@@ -1,0 +1,152 @@
+import { MenuConfig } from '../shared/config/menuConfig';
+
+// 고객사별 메뉴 설정 저장소 (실제로는 백엔드 API나 데이터베이스에서 관리)
+const clientMenuConfigs: Record<string, MenuConfig> = {
+  'default': {
+    items: [
+      {
+        id: 'ai-faq',
+        icon: 'MessageCircle',
+        label: 'AI FAQ',
+        action: 'navigate',
+        url: '/faq',
+        disabled: false
+      },
+      {
+        id: 'request-materials',
+        icon: 'FileText',
+        label: '資料請求',
+        action: 'navigate',
+        url: '/request-materials',
+        disabled: false
+      },
+      {
+        id: 'ai-consultation',
+        icon: 'Phone',
+        label: 'AI電話相談',
+        action: 'navigate',
+        url: '/consultation',
+        disabled: true  // 예시로 비활성화
+      }
+    ],
+    cta: {
+      label: '無料体験に応募する',
+      action: 'navigate',
+      url: '/free-trial'
+    }
+  },
+  'education-client': {
+    items: [
+      {
+        id: 'course-info',
+        icon: 'Book',
+        label: '講座情報',
+        action: 'navigate',
+        url: '/courses'
+      },
+      {
+        id: 'enrollment',
+        icon: 'UserPlus',
+        label: '入学案内',
+        action: 'navigate',
+        url: '/enrollment'
+      },
+      {
+        id: 'support',
+        icon: 'HelpCircle',
+        label: 'サポート',
+        action: 'navigate',
+        url: '/support'
+      }
+    ],
+    cta: {
+      label: '無料相談を予約',
+      action: 'navigate',
+      url: '/consultation'
+    }
+  },
+  'business-client': {
+    items: [
+      {
+        id: 'products',
+        icon: 'Package',
+        label: '製品情報',
+        action: 'navigate',
+        url: '/products'
+      },
+      {
+        id: 'pricing',
+        icon: 'CreditCard',
+        label: '料金プラン',
+        action: 'navigate',
+        url: '/pricing'
+      },
+      {
+        id: 'contact',
+        icon: 'Mail',
+        label: 'お問い合わせ',
+        action: 'navigate',
+        url: '/contact'
+      }
+    ],
+    cta: {
+      label: 'デモを申し込む',
+      action: 'navigate',
+      url: '/demo'
+    }
+  }
+};
+
+export class MenuService {
+  // 고객사별 메뉴 설정 가져오기
+  static getMenuConfig(clientId: string): MenuConfig {
+    return clientMenuConfigs[clientId] || clientMenuConfigs['default'];
+  }
+
+  // 메뉴 설정 업데이트 (관리자용)
+  static updateMenuConfig(clientId: string, config: MenuConfig): void {
+    clientMenuConfigs[clientId] = config;
+    // 실제로는 API 호출하여 백엔드에 저장
+    console.log(`Menu config updated for client: ${clientId}`, config);
+  }
+
+  // 메뉴 아이템 추가
+  static addMenuItem(clientId: string, item: any): void {
+    const config = this.getMenuConfig(clientId);
+    config.items.push(item);
+    this.updateMenuConfig(clientId, config);
+  }
+
+  // 메뉴 아이템 제거
+  static removeMenuItem(clientId: string, itemId: string): void {
+    const config = this.getMenuConfig(clientId);
+    config.items = config.items.filter(item => item.id !== itemId);
+    this.updateMenuConfig(clientId, config);
+  }
+
+  // CTA 업데이트
+  static updateCTA(clientId: string, cta: any): void {
+    const config = this.getMenuConfig(clientId);
+    config.cta = cta;
+    this.updateMenuConfig(clientId, config);
+  }
+
+  // 메뉴 아이템 활성/비활성 상태 변경
+  static setMenuItemDisabled(clientId: string, itemId: string, disabled: boolean): void {
+    const config = this.getMenuConfig(clientId);
+    const item = config.items.find(item => item.id === itemId);
+    if (item) {
+      item.disabled = disabled;
+      this.updateMenuConfig(clientId, config);
+    }
+  }
+
+  // 모든 메뉴 아이템 활성/비활성 상태 일괄 변경
+  static setAllMenuItemsDisabled(clientId: string, disabled: boolean): void {
+    const config = this.getMenuConfig(clientId);
+    config.items.forEach(item => {
+      item.disabled = disabled;
+    });
+    this.updateMenuConfig(clientId, config);
+  }
+}

--- a/src/shared/config/menuConfig.ts
+++ b/src/shared/config/menuConfig.ts
@@ -1,0 +1,58 @@
+export interface MenuItem {
+  id: string;
+  icon: string;
+  label: string;
+  action?: string;
+  url?: string;
+  disabled?: boolean;
+}
+
+export interface CTAConfig {
+  label: string;
+  action: string;
+  url?: string;
+}
+
+export interface MenuConfig {
+  items: MenuItem[];
+  cta?: CTAConfig;
+}
+
+// 기본 메뉴 설정
+export const defaultMenuConfig: MenuConfig = {
+  items: [
+    {
+      id: 'ai-faq',
+      icon: 'MessageCircle',
+      label: 'AI FAQ',
+      action: 'navigate',
+      url: '/faq'
+    },
+    {
+      id: 'request-materials',
+      icon: 'FileText',
+      label: '資料請求',
+      action: 'navigate',
+      url: '/request-materials'
+    },
+    {
+      id: 'ai-consultation',
+      icon: 'Phone',
+      label: 'AI電話相談',
+      action: 'navigate',
+      url: '/consultation'
+    }
+  ],
+  cta: {
+    label: '無料体験に応募する',
+    action: 'navigate',
+    url: '/free-trial'
+  }
+};
+
+// 고객사별 메뉴 설정을 가져오는 함수 
+export const getMenuConfig = async (clientId: string): Promise<MenuConfig> => {
+  // 동적 import를 사용하여 순환 의존성 방지
+  const { MenuService } = await import('../../services/menuService');
+  return MenuService.getMenuConfig(clientId);
+};


### PR DESCRIPTION
## Summary
- Implemented a customizable menu modal that appears from bottom chat input
- Improved application architecture following Atomic Design pattern
- Enhanced Storybook documentation and organization

## Changes

### ✨ New Features
- **MenuModal Component**: Bottom-sliding modal with keyboard state detection
  - Supports 3/4/6 menu item layouts based on Figma design
  - Client-specific menu configuration via MenuService
  - Keyboard-aware opening (waits for keyboard to close)
  
- **FAQ Integration**: Menu item click triggers FAQ category display
  - "AI FAQ" menu item shows user message and FAQ categories
  - Seamless integration with existing chat workflow

### 🏗️ Architecture Improvements
- **MainPage Refactoring**: Now uses ChatLayout template (Atomic Design)
- **TypingIndicator Component**: Extracted loading UI to separate component
- **Storybook Organization**: Sidebar now ordered as Atoms → Molecules → Organisms → Templates

### 🐛 Bug Fixes
- Fixed TopQuestions storybook stories by using valid category IDs
- Removed incorrect theme color usage in modal background

## Test Plan
- [ ] Test menu modal opening/closing on mobile devices
- [ ] Verify keyboard state detection works correctly
- [ ] Check FAQ category flow when clicking AI FAQ menu
- [ ] Confirm all Storybook stories render properly
- [ ] Test with different menu configurations (3/4/6 items)

## Screenshots
Menu modal supports different layouts:
- 3 items + CTA button
- 4 items (2x2 grid)
- 6 items (3x2 grid)

🤖 Generated with [Claude Code](https://claude.ai/code)