### PR TITLE
feat: implement JWE encryption for chat API with client_id and app_id

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,0 @@
-VITE_API_BASE_URL=https://coipekj2sl.execute-api.ap-northeast-1.amazonaws.com/dev
-VITE_CHAT_API_URL=https://67hnjuna66.execute-api.ap-northeast-1.amazonaws.com/prd-1
-VITE_ACCENT_COLOR=green
-VITE_SHOW_NAVIGATION_HEADER=true
-VITE_SHOW_TIMESTAMP=true
-VITE_FAQ_ICONS={"category1":{"type":"component","value":"ImageIcon"},"category2":{"type":"lucide","value":"Users"},"category3":{"type":"lucide","value":"Trophy"},"category4":{"type":"lucide","value":"FileText"},"other":{"type":"lucide","value":"MoreHorizontal"}}
-VITE_SHOW_GRADE_SELECTION=true

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ build
 public
 *storybook.log
 storybook-static
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,11 @@
       "name": "vite-react-typescript-starter",
       "version": "0.0.0",
       "dependencies": {
+        "@aws-sdk/client-cognito-identity": "^3.848.0",
+        "@aws-sdk/client-kms": "^3.848.0",
+        "@aws-sdk/client-sts": "^3.848.0",
+        "@aws-sdk/credential-providers": "^3.848.0",
+        "jose": "^6.0.12",
         "js-cookie": "^3.0.5",
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
@@ -70,6 +75,775 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.848.0.tgz",
+      "integrity": "sha512-Sin8aLnA81MgvUJrfQsBIQ1UJg4klWT3NuYYjExLiVQf3A0/F7Bfx1HTIyWXtSchY4QgGr7MMone0/0KZ4Dy9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/credential-provider-node": "3.848.0",
+        "@aws-sdk/middleware-host-header": "3.840.0",
+        "@aws-sdk/middleware-logger": "3.840.0",
+        "@aws-sdk/middleware-recursion-detection": "3.840.0",
+        "@aws-sdk/middleware-user-agent": "3.848.0",
+        "@aws-sdk/region-config-resolver": "3.840.0",
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/util-endpoints": "3.848.0",
+        "@aws-sdk/util-user-agent-browser": "3.840.0",
+        "@aws-sdk/util-user-agent-node": "3.848.0",
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/core": "^3.7.0",
+        "@smithy/fetch-http-handler": "^5.1.0",
+        "@smithy/hash-node": "^4.0.4",
+        "@smithy/invalid-dependency": "^4.0.4",
+        "@smithy/middleware-content-length": "^4.0.4",
+        "@smithy/middleware-endpoint": "^4.1.15",
+        "@smithy/middleware-retry": "^4.1.16",
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/middleware-stack": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/node-http-handler": "^4.1.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.7",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.23",
+        "@smithy/util-defaults-mode-node": "^4.0.23",
+        "@smithy/util-endpoints": "^3.0.6",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-retry": "^4.0.6",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.848.0.tgz",
+      "integrity": "sha512-kMb40oqSrEKtQChgdkJi5pCAWCFvthttgiGugwoXFZ/vDv54XRKGClAVzJ/b51Dkh1NLmuWgteXVtnDsfo9PHg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/credential-provider-node": "3.848.0",
+        "@aws-sdk/middleware-host-header": "3.840.0",
+        "@aws-sdk/middleware-logger": "3.840.0",
+        "@aws-sdk/middleware-recursion-detection": "3.840.0",
+        "@aws-sdk/middleware-user-agent": "3.848.0",
+        "@aws-sdk/region-config-resolver": "3.840.0",
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/util-endpoints": "3.848.0",
+        "@aws-sdk/util-user-agent-browser": "3.840.0",
+        "@aws-sdk/util-user-agent-node": "3.848.0",
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/core": "^3.7.0",
+        "@smithy/fetch-http-handler": "^5.1.0",
+        "@smithy/hash-node": "^4.0.4",
+        "@smithy/invalid-dependency": "^4.0.4",
+        "@smithy/middleware-content-length": "^4.0.4",
+        "@smithy/middleware-endpoint": "^4.1.15",
+        "@smithy/middleware-retry": "^4.1.16",
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/middleware-stack": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/node-http-handler": "^4.1.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.7",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.23",
+        "@smithy/util-defaults-mode-node": "^4.0.23",
+        "@smithy/util-endpoints": "^3.0.6",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-retry": "^4.0.6",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.848.0.tgz",
+      "integrity": "sha512-mD+gOwoeZQvbecVLGoCmY6pS7kg02BHesbtIxUj+PeBqYoZV5uLvjUOmuGfw1SfoSobKvS11urxC9S7zxU/Maw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/middleware-host-header": "3.840.0",
+        "@aws-sdk/middleware-logger": "3.840.0",
+        "@aws-sdk/middleware-recursion-detection": "3.840.0",
+        "@aws-sdk/middleware-user-agent": "3.848.0",
+        "@aws-sdk/region-config-resolver": "3.840.0",
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/util-endpoints": "3.848.0",
+        "@aws-sdk/util-user-agent-browser": "3.840.0",
+        "@aws-sdk/util-user-agent-node": "3.848.0",
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/core": "^3.7.0",
+        "@smithy/fetch-http-handler": "^5.1.0",
+        "@smithy/hash-node": "^4.0.4",
+        "@smithy/invalid-dependency": "^4.0.4",
+        "@smithy/middleware-content-length": "^4.0.4",
+        "@smithy/middleware-endpoint": "^4.1.15",
+        "@smithy/middleware-retry": "^4.1.16",
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/middleware-stack": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/node-http-handler": "^4.1.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.7",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.23",
+        "@smithy/util-defaults-mode-node": "^4.0.23",
+        "@smithy/util-endpoints": "^3.0.6",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-retry": "^4.0.6",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.848.0.tgz",
+      "integrity": "sha512-NA0ODCELiO76LAi9/aanufPpX+YDAgpLFMkqJTwLVrBvtCMYsgGi/ttYzGKHdxgQljOBmGLu99fTDq5mbuY55g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/credential-provider-node": "3.848.0",
+        "@aws-sdk/middleware-host-header": "3.840.0",
+        "@aws-sdk/middleware-logger": "3.840.0",
+        "@aws-sdk/middleware-recursion-detection": "3.840.0",
+        "@aws-sdk/middleware-user-agent": "3.848.0",
+        "@aws-sdk/region-config-resolver": "3.840.0",
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/util-endpoints": "3.848.0",
+        "@aws-sdk/util-user-agent-browser": "3.840.0",
+        "@aws-sdk/util-user-agent-node": "3.848.0",
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/core": "^3.7.0",
+        "@smithy/fetch-http-handler": "^5.1.0",
+        "@smithy/hash-node": "^4.0.4",
+        "@smithy/invalid-dependency": "^4.0.4",
+        "@smithy/middleware-content-length": "^4.0.4",
+        "@smithy/middleware-endpoint": "^4.1.15",
+        "@smithy/middleware-retry": "^4.1.16",
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/middleware-stack": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/node-http-handler": "^4.1.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.7",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.23",
+        "@smithy/util-defaults-mode-node": "^4.0.23",
+        "@smithy/util-endpoints": "^3.0.6",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-retry": "^4.0.6",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.846.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.846.0.tgz",
+      "integrity": "sha512-7CX0pM906r4WSS68fCTNMTtBCSkTtf3Wggssmx13gD40gcWEZXsU00KzPp1bYheNRyPlAq3rE22xt4wLPXbuxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/xml-builder": "3.821.0",
+        "@smithy/core": "^3.7.0",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/signature-v4": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.7",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-utf8": "^4.0.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.848.0.tgz",
+      "integrity": "sha512-2cm/Ye6ktagW1h7FmF4sgo8STZyBr2+0+L9lr/veuPKZVWoi/FyhJR3l0TtKrd8z78no9P5xbsGUmxoDLtsxiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.848.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.846.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.846.0.tgz",
+      "integrity": "sha512-QuCQZET9enja7AWVISY+mpFrEIeHzvkx/JEEbHYzHhUkxcnC2Kq2c0bB7hDihGD0AZd3Xsm653hk1O97qu69zg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.846.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.846.0.tgz",
+      "integrity": "sha512-Jh1iKUuepdmtreMYozV2ePsPcOF5W9p3U4tWhi3v6nDvz0GsBjzjAROW+BW8XMz9vAD3I9R+8VC3/aq63p5nlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/fetch-http-handler": "^5.1.0",
+        "@smithy/node-http-handler": "^4.1.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.7",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-stream": "^4.2.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.848.0.tgz",
+      "integrity": "sha512-r6KWOG+En2xujuMhgZu7dzOZV3/M5U/5+PXrG8dLQ3rdPRB3vgp5tc56KMqLwm/EXKRzAOSuw/UE4HfNOAB8Hw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/credential-provider-env": "3.846.0",
+        "@aws-sdk/credential-provider-http": "3.846.0",
+        "@aws-sdk/credential-provider-process": "3.846.0",
+        "@aws-sdk/credential-provider-sso": "3.848.0",
+        "@aws-sdk/credential-provider-web-identity": "3.848.0",
+        "@aws-sdk/nested-clients": "3.848.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/credential-provider-imds": "^4.0.6",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.848.0.tgz",
+      "integrity": "sha512-AblNesOqdzrfyASBCo1xW3uweiSro4Kft9/htdxLeCVU1KVOnFWA5P937MNahViRmIQm2sPBCqL8ZG0u9lnh5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.846.0",
+        "@aws-sdk/credential-provider-http": "3.846.0",
+        "@aws-sdk/credential-provider-ini": "3.848.0",
+        "@aws-sdk/credential-provider-process": "3.846.0",
+        "@aws-sdk/credential-provider-sso": "3.848.0",
+        "@aws-sdk/credential-provider-web-identity": "3.848.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/credential-provider-imds": "^4.0.6",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.846.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.846.0.tgz",
+      "integrity": "sha512-mEpwDYarJSH+CIXnnHN0QOe0MXI+HuPStD6gsv3z/7Q6ESl8KRWon3weFZCDnqpiJMUVavlDR0PPlAFg2MQoPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.848.0.tgz",
+      "integrity": "sha512-pozlDXOwJZL0e7w+dqXLgzVDB7oCx4WvtY0sk6l4i07uFliWF/exupb6pIehFWvTUcOvn5aFTTqcQaEzAD5Wsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.848.0",
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/token-providers": "3.848.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.848.0.tgz",
+      "integrity": "sha512-D1fRpwPxtVDhcSc/D71exa2gYweV+ocp4D3brF0PgFd//JR3XahZ9W24rVnTQwYEcK9auiBZB89Ltv+WbWN8qw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/nested-clients": "3.848.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.848.0.tgz",
+      "integrity": "sha512-lRDuU05YC+r/1JmRULngJQli7scP5hmq0/7D+xw1s8eRM0H2auaH7LQFlq/SLxQZLMkVNPCrmsug3b3KcLj1NA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.848.0",
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.848.0",
+        "@aws-sdk/credential-provider-env": "3.846.0",
+        "@aws-sdk/credential-provider-http": "3.846.0",
+        "@aws-sdk/credential-provider-ini": "3.848.0",
+        "@aws-sdk/credential-provider-node": "3.848.0",
+        "@aws-sdk/credential-provider-process": "3.846.0",
+        "@aws-sdk/credential-provider-sso": "3.848.0",
+        "@aws-sdk/credential-provider-web-identity": "3.848.0",
+        "@aws-sdk/nested-clients": "3.848.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/core": "^3.7.0",
+        "@smithy/credential-provider-imds": "^4.0.6",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.840.0.tgz",
+      "integrity": "sha512-ub+hXJAbAje94+Ya6c6eL7sYujoE8D4Bumu1NUI8TXjUhVVn0HzVWQjpRLshdLsUp1AW7XyeJaxyajRaJQ8+Xg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.840.0.tgz",
+      "integrity": "sha512-lSV8FvjpdllpGaRspywss4CtXV8M7NNNH+2/j86vMH+YCOZ6fu2T/TyFd/tHwZ92vDfHctWkRbQxg0bagqwovA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.840.0.tgz",
+      "integrity": "sha512-Gu7lGDyfddyhIkj1Z1JtrY5NHb5+x/CRiB87GjaSrKxkDaydtX2CU977JIABtt69l9wLbcGDIQ+W0uJ5xPof7g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.848.0.tgz",
+      "integrity": "sha512-rjMuqSWJEf169/ByxvBqfdei1iaduAnfolTshsZxwcmLIUtbYrFUmts0HrLQqsAG8feGPpDLHA272oPl+NTCCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/util-endpoints": "3.848.0",
+        "@smithy/core": "^3.7.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.848.0.tgz",
+      "integrity": "sha512-joLsyyo9u61jnZuyYzo1z7kmS7VgWRAkzSGESVzQHfOA1H2PYeUFek6vLT4+c9xMGrX/Z6B0tkRdzfdOPiatLg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/middleware-host-header": "3.840.0",
+        "@aws-sdk/middleware-logger": "3.840.0",
+        "@aws-sdk/middleware-recursion-detection": "3.840.0",
+        "@aws-sdk/middleware-user-agent": "3.848.0",
+        "@aws-sdk/region-config-resolver": "3.840.0",
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/util-endpoints": "3.848.0",
+        "@aws-sdk/util-user-agent-browser": "3.840.0",
+        "@aws-sdk/util-user-agent-node": "3.848.0",
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/core": "^3.7.0",
+        "@smithy/fetch-http-handler": "^5.1.0",
+        "@smithy/hash-node": "^4.0.4",
+        "@smithy/invalid-dependency": "^4.0.4",
+        "@smithy/middleware-content-length": "^4.0.4",
+        "@smithy/middleware-endpoint": "^4.1.15",
+        "@smithy/middleware-retry": "^4.1.16",
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/middleware-stack": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/node-http-handler": "^4.1.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/smithy-client": "^4.4.7",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.23",
+        "@smithy/util-defaults-mode-node": "^4.0.23",
+        "@smithy/util-endpoints": "^3.0.6",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-retry": "^4.0.6",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.840.0.tgz",
+      "integrity": "sha512-Qjnxd/yDv9KpIMWr90ZDPtRj0v75AqGC92Lm9+oHXZ8p1MjG5JE2CW0HL8JRgK9iKzgKBL7pPQRXI8FkvEVfrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-config-provider": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.848.0.tgz",
+      "integrity": "sha512-oNPyM4+Di2Umu0JJRFSxDcKQ35+Chl/rAwD47/bS0cDPI8yrao83mLXLeDqpRPHyQW4sXlP763FZcuAibC0+mg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.846.0",
+        "@aws-sdk/nested-clients": "3.848.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.840.0.tgz",
+      "integrity": "sha512-xliuHaUFZxEx1NSXeLLZ9Dyu6+EJVQKEoD+yM+zqUo3YDZ7medKJWY6fIOKiPX/N7XbLdBYwajb15Q7IL8KkeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.848.0.tgz",
+      "integrity": "sha512-fY/NuFFCq/78liHvRyFKr+aqq1aA/uuVSANjzr5Ym8c+9Z3HRPE9OrExAHoMrZ6zC8tHerQwlsXYYH5XZ7H+ww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "@smithy/util-endpoints": "^3.0.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.804.0.tgz",
+      "integrity": "sha512-zVoRfpmBVPodYlnMjgVjfGoEZagyRF5IPn3Uo6ZvOZp24chnW/FRstH7ESDHDDRga4z3V+ElUQHKpFDXWyBW5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.840.0.tgz",
+      "integrity": "sha512-JdyZM3EhhL4PqwFpttZu1afDpPJCCc3eyZOLi+srpX11LsGj6sThf47TYQN75HT1CarZ7cCdQHGzP2uy3/xHfQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/types": "^4.3.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.848.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.848.0.tgz",
+      "integrity": "sha512-Zz1ft9NiLqbzNj/M0jVNxaoxI2F4tGXN0ZbZIj+KJ+PbJo+w5+Jo6d0UDAtbj3AEd79pjcCaP4OA9NTVzItUdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.848.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.821.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.821.0.tgz",
+      "integrity": "sha512-DIIotRnefVL6DiaHtO6/21DhJ4JZnnIwdNbpwiAhdt/AVbttcE4yw925gsjur0OGv5BTYXQXU3YnANBYnZjuQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2674,6 +3448,586 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@smithy/abort-controller": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.4.tgz",
+      "integrity": "sha512-gJnEjZMvigPDQWHrW3oPrFhQtkrgqBkyjj3pCIdF3A5M6vsZODG93KNlfJprv6bp4245bdT32fsHK4kkH3KYDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.4.tgz",
+      "integrity": "sha512-prmU+rDddxHOH0oNcwemL+SwnzcG65sBF2yXRO7aeXIn/xTlq2pX7JLVbkBnVLowHLg4/OL4+jBmv9hVrVGS+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-config-provider": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.7.1.tgz",
+      "integrity": "sha512-ExRCsHnXFtBPnM7MkfKBPcBBdHw1h/QS/cbNw4ho95qnyNHvnpmGbR39MIAv9KggTr5qSPxRSEL+hRXlyGyGQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-stream": "^4.2.3",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.6.tgz",
+      "integrity": "sha512-hKMWcANhUiNbCJouYkZ9V3+/Qf9pteR1dnwgdyzR09R4ODEYx8BbUysHwRSyex4rZ9zapddZhLFTnT4ZijR4pw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.1.0.tgz",
+      "integrity": "sha512-mADw7MS0bYe2OGKkHYMaqarOXuDwRbO6ArD91XhHcl2ynjGCFF+hvqf0LyQcYxkA1zaWjefSkU7Ne9mqgApSgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/querystring-builder": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-base64": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.4.tgz",
+      "integrity": "sha512-qnbTPUhCVnCgBp4z4BUJUhOEkVwxiEi1cyFM+Zj6o+aY8OFGxUQleKWq8ltgp3dujuhXojIvJWdoqpm6dVO3lQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-buffer-from": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.4.tgz",
+      "integrity": "sha512-bNYMi7WKTJHu0gn26wg8OscncTt1t2b8KcsZxvOv56XA6cyXtOAAAaNP7+m45xfppXfOatXF3Sb1MNsLUgVLTw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
+      "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.4.tgz",
+      "integrity": "sha512-F7gDyfI2BB1Kc+4M6rpuOLne5LOcEknH1n6UQB69qv+HucXBR1rkzXBnQTB2q46sFy1PM/zuSJOB532yc8bg3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.16.tgz",
+      "integrity": "sha512-plpa50PIGLqzMR2ANKAw2yOW5YKS626KYKqae3atwucbz4Ve4uQ9K9BEZxDLIFmCu7hKLcrq2zmj4a+PfmUV5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.7.1",
+        "@smithy/middleware-serde": "^4.0.8",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
+        "@smithy/util-middleware": "^4.0.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.1.17",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.17.tgz",
+      "integrity": "sha512-gsCimeG6BApj0SBecwa1Be+Z+JOJe46iy3B3m3A8jKJHf7eIihP76Is4LwLrbJ1ygoS7Vg73lfqzejmLOrazUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/service-error-classification": "^4.0.6",
+        "@smithy/smithy-client": "^4.4.8",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-retry": "^4.0.6",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.8.tgz",
+      "integrity": "sha512-iSSl7HJoJaGyMIoNn2B7czghOVwJ9nD7TMvLhMWeSB5vt0TnEYyRRqPJu/TqW76WScaNvYYB8nRoiBHR9S1Ddw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.4.tgz",
+      "integrity": "sha512-kagK5ggDrBUCCzI93ft6DjteNSfY8Ulr83UtySog/h09lTIOAJ/xUSObutanlPT0nhoHAkpmW9V5K8oPyLh+QA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.1.3.tgz",
+      "integrity": "sha512-HGHQr2s59qaU1lrVH6MbLlmOBxadtzTsoO4c+bF5asdgVik3I8o7JIOzoeqWc5MjVa+vD36/LWE0iXKpNqooRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/shared-ini-file-loader": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.1.0.tgz",
+      "integrity": "sha512-vqfSiHz2v8b3TTTrdXi03vNz1KLYYS3bhHCDv36FYDqxT7jvTll1mMnCrkD+gOvgwybuunh/2VmvOMqwBegxEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/querystring-builder": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.4.tgz",
+      "integrity": "sha512-qHJ2sSgu4FqF4U/5UUp4DhXNmdTrgmoAai6oQiM+c5RZ/sbDwJ12qxB1M6FnP+Tn/ggkPZf9ccn4jqKSINaquw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.2.tgz",
+      "integrity": "sha512-rOG5cNLBXovxIrICSBm95dLqzfvxjEmuZx4KK3hWwPFHGdW3lxY0fZNXfv2zebfRO7sJZ5pKJYHScsqopeIWtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.4.tgz",
+      "integrity": "sha512-SwREZcDnEYoh9tLNgMbpop+UTGq44Hl9tdj3rf+yeLcfH7+J8OXEBaMc2kDxtyRHu8BhSg9ADEx0gFHvpJgU8w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-uri-escape": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.4.tgz",
+      "integrity": "sha512-6yZf53i/qB8gRHH/l2ZwUG5xgkPgQF15/KxH0DdXMDHjesA9MeZje/853ifkSY0x4m5S+dfDZ+c4x439PF0M2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.6.tgz",
+      "integrity": "sha512-RRoTDL//7xi4tn5FrN2NzH17jbgmnKidUqd4KvquT0954/i6CXXkh1884jBiunq24g9cGtPBEXlU40W6EpNOOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.4.tgz",
+      "integrity": "sha512-63X0260LoFBjrHifPDs+nM9tV0VMkOTl4JRMYNuKh/f5PauSjowTfvF3LogfkWdcPoxsA9UjqEOgjeYIbhb7Nw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.1.2.tgz",
+      "integrity": "sha512-d3+U/VpX7a60seHziWnVZOHuEgJlclufjkS6zhXvxcJgkJq4UWdH5eOBLzHRMx6gXjsdT9h6lfpmLzbrdupHgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.0.0",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-hex-encoding": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-uri-escape": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.4.8.tgz",
+      "integrity": "sha512-pcW691/lx7V54gE+dDGC26nxz8nrvnvRSCJaIYD6XLPpOInEZeKdV/SpSux+wqeQ4Ine7LJQu8uxMvobTIBK0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.7.1",
+        "@smithy/middleware-endpoint": "^4.1.16",
+        "@smithy/middleware-stack": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.2",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-stream": "^4.2.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.1.tgz",
+      "integrity": "sha512-UqKOQBL2x6+HWl3P+3QqFD4ncKq0I8Nuz9QItGv5WuKuMHuuwlhvqcZCoXGfc+P1QmfJE7VieykoYYmrOoFJxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.4.tgz",
+      "integrity": "sha512-eMkc144MuN7B0TDA4U2fKs+BqczVbk3W+qIvcoCY6D1JY3hnAdCuhCZODC+GAeaxj0p6Jroz4+XMUn3PCxQQeQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.0.4",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
+      "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
+      "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
+      "integrity": "sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+      "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
+      "integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.0.24",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.24.tgz",
+      "integrity": "sha512-UkQNgaQ+bidw1MgdgPO1z1k95W/v8Ej/5o/T/Is8PiVUYPspl/ZxV6WO/8DrzZQu5ULnmpB9CDdMSRwgRc21AA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/smithy-client": "^4.4.8",
+        "@smithy/types": "^4.3.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.0.24",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.24.tgz",
+      "integrity": "sha512-phvGi/15Z4MpuQibTLOYIumvLdXb+XIJu8TA55voGgboln85jytA3wiD7CkUE8SNcWqkkb+uptZKPiuFouX/7g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.1.4",
+        "@smithy/credential-provider-imds": "^4.0.6",
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/property-provider": "^4.0.4",
+        "@smithy/smithy-client": "^4.4.8",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.6.tgz",
+      "integrity": "sha512-YARl3tFL3WgPuLzljRUnrS2ngLiUtkwhQtj8PAL13XZSyUiNLQxwG3fBBq3QXFqGFUXepIN73pINp3y8c2nBmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.1.3",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
+      "integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.4.tgz",
+      "integrity": "sha512-9MLKmkBmf4PRb0ONJikCbCwORACcil6gUWojwARCClT7RmLzF04hUR4WdRprIXal7XVyrddadYNfp2eF3nrvtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.6.tgz",
+      "integrity": "sha512-+YekoF2CaSMv6zKrA6iI/N9yva3Gzn4L6n35Luydweu5MMPYpiGZlWqehPHDHyNbnyaYlz/WJyYAZnC+loBDZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.0.6",
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.3.tgz",
+      "integrity": "sha512-cQn412DWHHFNKrQfbHY8vSFI3nTROY1aIKji9N0tpp8gUABRilr7wdf8fqBbSlXresobM+tQFNk6I+0LXK/YZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.1.0",
+        "@smithy/node-http-handler": "^4.1.0",
+        "@smithy/types": "^4.3.1",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-buffer-from": "^4.0.0",
+        "@smithy/util-hex-encoding": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
+      "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+      "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@storybook/addon-a11y": {
       "version": "9.0.16",
       "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-9.0.16.tgz",
@@ -4433,6 +5787,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -5949,6 +7309,24 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastq": {
       "version": "1.17.1",
@@ -9371,6 +10749,15 @@
         "@sideway/pinpoint": "^2.0.0"
       }
     },
+    "node_modules/jose": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.0.12.tgz",
+      "integrity": "sha512-T8xypXs8CpmiIi78k0E+Lk7T2zlK4zDyg+o1CZ4AkOHgDg98ogdP2BeZ61lTFKFyoEwJ9RgAgN+SdM3iPgNonQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-cookie": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
@@ -11809,6 +13196,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/sucrase": {
       "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
@@ -12068,7 +13467,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,11 @@
     "chromatic": "chromatic --exit-zero-on-changes"
   },
   "dependencies": {
+    "@aws-sdk/client-cognito-identity": "^3.848.0",
+    "@aws-sdk/client-kms": "^3.848.0",
+    "@aws-sdk/client-sts": "^3.848.0",
+    "@aws-sdk/credential-providers": "^3.848.0",
+    "jose": "^6.0.12",
     "js-cookie": "^3.0.5",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,15 +2,23 @@ import { StrictMode } from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { LocaleProvider } from './contexts/LocaleContext';
 import MainPage from './pages/MainPage';
+import { CognitoTestPage, JWETestPage } from './dev';
 
 function App() {
   return (
     <BrowserRouter>
       <LocaleProvider>
-          <Routes>
-            <Route path="/" element={<MainPage />} />
-            <Route path="*" element={<Navigate to="/" replace />} />
-          </Routes>
+      <Routes>
+          <Route path="/" element={<MainPage />} />
+          {/* 개발/테스트용 라우트 */}
+          {!import.meta.env.PROD && (
+            <>
+              <Route path="/dev/jwe-test" element={<JWETestPage />} />
+              <Route path="/dev/cognito-test" element={<CognitoTestPage />} />
+            </>
+          )}
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
       </LocaleProvider>
     </BrowserRouter>
   );

--- a/src/dev/components/DevNavigation.tsx
+++ b/src/dev/components/DevNavigation.tsx
@@ -1,0 +1,47 @@
+/**
+ * 개발 환경 전용 네비게이션 컴포넌트
+ */
+
+import React from 'react';
+import { Link, useLocation } from 'react-router-dom';
+
+export const DevNavigation: React.FC = () => {
+  const location = useLocation();
+  
+  // 개발 환경이 아니거나 메인 페이지이면 렌더링하지 않음
+  if (import.meta.env.PROD || location.pathname === '/') {
+    return null;
+  }
+
+  const devRoutes = [
+    { path: '/', label: '메인' },
+    { path: '/dev/jwe-test', label: 'JWE 테스트' },
+    { path: '/dev/cognito-test', label: 'Cognito 테스트' }
+  ];
+
+  return (
+    <div className="fixed top-0 left-0 right-0 z-50 bg-red-600 text-white text-sm py-2 px-4">
+      <div className="flex items-center justify-between max-w-6xl mx-auto">
+        <div className="flex items-center gap-1">
+          <span className="font-bold">🛠️ DEV</span>
+          <span className="hidden sm:inline">모드</span>
+        </div>
+        <nav className="flex items-center gap-4">
+          {devRoutes.map((route) => (
+            <Link
+              key={route.path}
+              to={route.path}
+              className={`px-2 py-1 rounded text-xs transition-colors ${
+                location.pathname === route.path
+                  ? 'bg-white text-red-600 font-medium'
+                  : 'hover:bg-red-500'
+              }`}
+            >
+              {route.label}
+            </Link>
+          ))}
+        </nav>
+      </div>
+    </div>
+  );
+};

--- a/src/dev/components/index.ts
+++ b/src/dev/components/index.ts
@@ -1,0 +1,5 @@
+/**
+ * 개발 전용 컴포넌트 export
+ */
+
+export { DevNavigation } from './DevNavigation';

--- a/src/dev/index.ts
+++ b/src/dev/index.ts
@@ -1,0 +1,7 @@
+/**
+ * 개발/테스트 환경 전용 모듈
+ * 프로덕션 빌드에서는 이 폴더를 제외할 수 있습니다.
+ */
+
+export * from './pages';
+export * from './components';

--- a/src/dev/pages/CognitoTestPage.tsx
+++ b/src/dev/pages/CognitoTestPage.tsx
@@ -1,0 +1,1288 @@
+/**
+ * Cognito Identity Pool 연결 테스트 컴포넌트
+ * 단계별로 테스트하면서 문제를 파악합니다.
+ */
+
+import React, { useState } from 'react';
+import { CognitoIdentityClient, GetIdCommand, GetCredentialsForIdentityCommand } from '@aws-sdk/client-cognito-identity';
+import { STSClient, AssumeRoleCommand } from '@aws-sdk/client-sts';
+import { KMSClient, GetPublicKeyCommand } from '@aws-sdk/client-kms';
+import { generateJWEToken, createTestPayload } from '../../services/jwe/jweTokenGenerator';
+import { chatJWEService } from '../../services/jwe/chatJWEService';
+import { sendChatMessage } from '../../services/api/chat';
+
+interface TestResult {
+  step: string;
+  status: 'pending' | 'success' | 'error';
+  message: string;
+  data?: any;
+}
+
+export const CognitoTestPage: React.FC = () => {
+  const [results, setResults] = useState<TestResult[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [authMode, setAuthMode] = useState<'iam' | 'profile'>('iam');
+  const [testMode, setTestMode] = useState<'cognito' | 'kms' | 'jwe' | 'integration' | 'chat'>('cognito');
+  const [lastPublicKey, setLastPublicKey] = useState<Uint8Array | null>(null);
+  const [lastJWEToken, setLastJWEToken] = useState<string | null>(null);
+
+  const addResult = (result: TestResult) => {
+    setResults(prev => {
+      const newResults = [...prev, result];
+      // 새로운 결과가 추가되면 스크롤을 아래로 이동
+      setTimeout(() => {
+        // 전체 페이지를 맨 아래로 스크롤
+        window.scrollTo({ 
+          top: document.body.scrollHeight, 
+          behavior: 'smooth' 
+        });
+      }, 100);
+      return newResults;
+    });
+  };
+
+  const clearResults = () => {
+    setResults([]);
+  };
+
+  const testIAMAuthentication = async () => {
+    setIsLoading(true);
+    clearResults();
+
+    try {
+      // 1단계: IAM 환경변수 확인
+      addResult({
+        step: '1. IAM 환경변수 확인',
+        status: 'pending',
+        message: 'IAM 자격증명 환경변수 확인 중...'
+      });
+
+      const accessKeyId = import.meta.env.VITE_AWS_ACCESS_KEY_ID;
+      const secretAccessKey = import.meta.env.VITE_AWS_SECRET_ACCESS_KEY;
+      const region = import.meta.env.VITE_AWS_REGION;
+      const frontendRoleArn = import.meta.env.VITE_FRONTEND_ROLE_ARN;
+
+      if (!accessKeyId || !secretAccessKey || !region || !frontendRoleArn) {
+        addResult({
+          step: '1. IAM 환경변수 확인',
+          status: 'error',
+          message: 'IAM 자격증명 환경변수가 누락되었습니다',
+          data: { 
+            hasAccessKeyId: !!accessKeyId,
+            hasSecretAccessKey: !!secretAccessKey,
+            region,
+            frontendRoleArn 
+          }
+        });
+        return;
+      }
+
+      addResult({
+        step: '1. IAM 환경변수 확인',
+        status: 'success',
+        message: 'IAM 환경변수 확인 완료',
+        data: { region, frontendRoleArn, accessKeyId: accessKeyId.slice(0, 8) + '...' }
+      });
+
+      // 2단계: STS 클라이언트 생성 및 역할 가정
+      addResult({
+        step: '2. STS 역할 가정',
+        status: 'pending',
+        message: 'Frontend Role 가정 중...'
+      });
+
+      const stsClient = new STSClient({
+        region: region,
+        credentials: {
+          accessKeyId: accessKeyId,
+          secretAccessKey: secretAccessKey,
+        }
+      });
+
+      const assumeRoleCommand = new AssumeRoleCommand({
+        RoleArn: frontendRoleArn,
+        RoleSessionName: 'frontend-iam-auth-session',
+        DurationSeconds: 3600
+      });
+
+      const assumeRoleResponse = await stsClient.send(assumeRoleCommand);
+
+      if (!assumeRoleResponse.Credentials) {
+        addResult({
+          step: '2. STS 역할 가정',
+          status: 'error',
+          message: 'Frontend Role 가정에 실패했습니다'
+        });
+        return;
+      }
+
+      addResult({
+        step: '2. STS 역할 가정',
+        status: 'success',
+        message: 'Frontend Role 가정 완료',
+        data: {
+          accessKeyId: assumeRoleResponse.Credentials.AccessKeyId?.slice(0, 8) + '...',
+          expiration: assumeRoleResponse.Credentials.Expiration?.toISOString()
+        }
+      });
+
+      // 3단계: Cognito Identity Pool에 인증된 사용자로 접근
+      addResult({
+        step: '3. Cognito 인증된 사용자 접근',
+        status: 'pending',
+        message: 'Cognito에 인증된 사용자로 접근 중...'
+      });
+
+      const cognitoClient = new CognitoIdentityClient({
+        region: region,
+        credentials: {
+          accessKeyId: assumeRoleResponse.Credentials.AccessKeyId!,
+          secretAccessKey: assumeRoleResponse.Credentials.SecretAccessKey!,
+          sessionToken: assumeRoleResponse.Credentials.SessionToken!
+        }
+      });
+
+      const identityPoolId = import.meta.env.VITE_COGNITO_IDENTITY_POOL_ID;
+      const getIdCommand = new GetIdCommand({
+        IdentityPoolId: identityPoolId,
+      });
+
+      const identityResponse = await cognitoClient.send(getIdCommand);
+
+      if (!identityResponse.IdentityId) {
+        addResult({
+          step: '3. Cognito 인증된 사용자 접근',
+          status: 'error',
+          message: 'Cognito Identity ID 획득 실패'
+        });
+        return;
+      }
+
+      addResult({
+        step: '3. Cognito 인증된 사용자 접근',
+        status: 'success',
+        message: 'Cognito 인증된 사용자 접근 완료',
+        data: { identityId: identityResponse.IdentityId }
+      });
+
+      // 4단계: 인증된 사용자 자격증명 획득
+      addResult({
+        step: '4. 인증된 사용자 자격증명 획득',
+        status: 'pending',
+        message: '인증된 사용자 자격증명 요청 중...'
+      });
+
+      const getCredentialsCommand = new GetCredentialsForIdentityCommand({
+        IdentityId: identityResponse.IdentityId,
+      });
+
+      const credentialsResponse = await cognitoClient.send(getCredentialsCommand);
+
+      if (!credentialsResponse.Credentials) {
+        addResult({
+          step: '4. 인증된 사용자 자격증명 획득',
+          status: 'error',
+          message: '인증된 사용자 자격증명 획득 실패'
+        });
+        return;
+      }
+
+      addResult({
+        step: '4. 인증된 사용자 자격증명 획득',
+        status: 'success',
+        message: '인증된 사용자 자격증명 획득 완료',
+        data: {
+          accessKeyId: credentialsResponse.Credentials.AccessKeyId,
+          secretAccessKey: credentialsResponse.Credentials.SecretKey?.slice(0, 10) + '...',
+          sessionToken: credentialsResponse.Credentials.SessionToken?.slice(0, 20) + '...',
+          expiration: credentialsResponse.Credentials.Expiration?.toISOString()
+        }
+      });
+
+      addResult({
+        step: '✅ IAM 인증 테스트 완료',
+        status: 'success',
+        message: 'IAM 사용자 인증이 정상적으로 작동합니다!'
+      });
+
+    } catch (error) {
+      addResult({
+        step: '❌ IAM 인증 테스트 실패',
+        status: 'error',
+        message: `오류 발생: ${error instanceof Error ? error.message : '알 수 없는 오류'}`,
+        data: error
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const testProfileAuthentication = async () => {
+    setIsLoading(true);
+    clearResults();
+
+    try {
+      // 1단계: AWS Profile 확인
+      addResult({
+        step: '1. AWS Profile 확인',
+        status: 'pending',
+        message: 'AWS Profile 자격증명 확인 중...'
+      });
+
+      const region = import.meta.env.VITE_AWS_REGION;
+      const frontendRoleArn = import.meta.env.VITE_FRONTEND_ROLE_ARN;
+      const profileName = import.meta.env.VITE_AWS_PROFILE || 'default';
+
+      if (!region || !frontendRoleArn) {
+        addResult({
+          step: '1. AWS Profile 확인',
+          status: 'error',
+          message: '필수 환경변수가 누락되었습니다',
+          data: { region, frontendRoleArn, profileName }
+        });
+        return;
+      }
+
+      addResult({
+        step: '1. AWS Profile 확인',
+        status: 'success',
+        message: 'AWS Profile 환경변수 확인 완료',
+        data: { region, frontendRoleArn, profileName }
+      });
+
+      // 2단계: Profile 자격증명으로 STS 역할 가정
+      addResult({
+        step: '2. Profile로 STS 역할 가정',
+        status: 'pending',
+        message: 'Profile 자격증명으로 Frontend Role 가정 중...'
+      });
+
+      // Profile 인증은 브라우저 환경에서 직접 지원되지 않으므로
+      // 환경변수를 통해 Profile 자격증명을 사용
+      const accessKeyId = import.meta.env.VITE_AWS_ACCESS_KEY_ID;
+      const secretAccessKey = import.meta.env.VITE_AWS_SECRET_ACCESS_KEY;
+      
+      if (!accessKeyId || !secretAccessKey) {
+        addResult({
+          step: '2. Profile로 STS 역할 가정',
+          status: 'error',
+          message: 'Profile 자격증명을 환경변수로 설정해야 합니다',
+          data: { 
+            note: 'VITE_AWS_ACCESS_KEY_ID, VITE_AWS_SECRET_ACCESS_KEY 환경변수 필요',
+            profileName
+          }
+        });
+        return;
+      }
+
+      const stsClient = new STSClient({
+        region: region,
+        credentials: {
+          accessKeyId: accessKeyId,
+          secretAccessKey: secretAccessKey,
+        }
+      });
+
+      const assumeRoleCommand = new AssumeRoleCommand({
+        RoleArn: frontendRoleArn,
+        RoleSessionName: 'frontend-profile-auth-session',
+        DurationSeconds: 3600
+      });
+
+      const assumeRoleResponse = await stsClient.send(assumeRoleCommand);
+
+      if (!assumeRoleResponse.Credentials) {
+        addResult({
+          step: '2. Profile로 STS 역할 가정',
+          status: 'error',
+          message: 'Profile로 Frontend Role 가정에 실패했습니다'
+        });
+        return;
+      }
+
+      addResult({
+        step: '2. Profile로 STS 역할 가정',
+        status: 'success',
+        message: 'Profile로 Frontend Role 가정 완료',
+        data: {
+          accessKeyId: assumeRoleResponse.Credentials.AccessKeyId?.slice(0, 8) + '...',
+          expiration: assumeRoleResponse.Credentials.Expiration?.toISOString(),
+          profileName
+        }
+      });
+
+      // 3단계: Cognito Identity Pool에 인증된 사용자로 접근
+      addResult({
+        step: '3. Cognito 인증된 사용자 접근',
+        status: 'pending',
+        message: 'Cognito에 인증된 사용자로 접근 중...'
+      });
+
+      const cognitoClient = new CognitoIdentityClient({
+        region: region,
+        credentials: {
+          accessKeyId: assumeRoleResponse.Credentials.AccessKeyId!,
+          secretAccessKey: assumeRoleResponse.Credentials.SecretAccessKey!,
+          sessionToken: assumeRoleResponse.Credentials.SessionToken!
+        }
+      });
+
+      const identityPoolId = import.meta.env.VITE_COGNITO_IDENTITY_POOL_ID;
+      const getIdCommand = new GetIdCommand({
+        IdentityPoolId: identityPoolId,
+      });
+
+      const identityResponse = await cognitoClient.send(getIdCommand);
+
+      if (!identityResponse.IdentityId) {
+        addResult({
+          step: '3. Cognito 인증된 사용자 접근',
+          status: 'error',
+          message: 'Cognito Identity ID 획득 실패'
+        });
+        return;
+      }
+
+      addResult({
+        step: '3. Cognito 인증된 사용자 접근',
+        status: 'success',
+        message: 'Cognito 인증된 사용자 접근 완료',
+        data: { identityId: identityResponse.IdentityId }
+      });
+
+      // 4단계: 인증된 사용자 자격증명 획득
+      addResult({
+        step: '4. 인증된 사용자 자격증명 획득',
+        status: 'pending',
+        message: '인증된 사용자 자격증명 요청 중...'
+      });
+
+      const getCredentialsCommand = new GetCredentialsForIdentityCommand({
+        IdentityId: identityResponse.IdentityId,
+      });
+
+      const credentialsResponse = await cognitoClient.send(getCredentialsCommand);
+
+      if (!credentialsResponse.Credentials) {
+        addResult({
+          step: '4. 인증된 사용자 자격증명 획득',
+          status: 'error',
+          message: '인증된 사용자 자격증명 획득 실패'
+        });
+        return;
+      }
+
+      addResult({
+        step: '4. 인증된 사용자 자격증명 획득',
+        status: 'success',
+        message: '인증된 사용자 자격증명 획득 완료',
+        data: {
+          accessKeyId: credentialsResponse.Credentials.AccessKeyId,
+          secretAccessKey: credentialsResponse.Credentials.SecretKey?.slice(0, 10) + '...',
+          sessionToken: credentialsResponse.Credentials.SessionToken?.slice(0, 20) + '...',
+          expiration: credentialsResponse.Credentials.Expiration?.toISOString()
+        }
+      });
+
+      addResult({
+        step: '✅ Profile 인증 테스트 완료',
+        status: 'success',
+        message: 'AWS Profile 인증이 정상적으로 작동합니다!'
+      });
+
+    } catch (error) {
+      addResult({
+        step: '❌ Profile 인증 테스트 실패',
+        status: 'error',
+        message: `오류 발생: ${error instanceof Error ? error.message : '알 수 없는 오류'}`,
+        data: error
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const testCognitoConnection = async () => {
+    setIsLoading(true);
+    clearResults();
+
+    try {
+      // 1단계: 환경변수 확인
+      addResult({
+        step: '1. 환경변수 확인',
+        status: 'pending',
+        message: '환경변수 로드 중...'
+      });
+
+      const identityPoolId = import.meta.env.VITE_COGNITO_IDENTITY_POOL_ID;
+      const region = import.meta.env.VITE_AWS_REGION;
+
+      if (!identityPoolId || !region) {
+        addResult({
+          step: '1. 환경변수 확인',
+          status: 'error',
+          message: '필수 환경변수가 누락되었습니다',
+          data: { identityPoolId, region }
+        });
+        return;
+      }
+
+      addResult({
+        step: '1. 환경변수 확인',
+        status: 'success',
+        message: '환경변수 로드 완료',
+        data: { identityPoolId, region }
+      });
+
+      // 2단계: Cognito 클라이언트 생성
+      addResult({
+        step: '2. Cognito 클라이언트 생성',
+        status: 'pending',
+        message: 'Cognito 클라이언트 생성 중...'
+      });
+
+      const cognitoClient = new CognitoIdentityClient({
+        region: region,
+      });
+
+      addResult({
+        step: '2. Cognito 클라이언트 생성',
+        status: 'success',
+        message: 'Cognito 클라이언트 생성 완료'
+      });
+
+      // 3단계: Identity ID 획득
+      addResult({
+        step: '3. Identity ID 획득',
+        status: 'pending',
+        message: 'Cognito Identity ID 요청 중...'
+      });
+
+      const getIdCommand = new GetIdCommand({
+        IdentityPoolId: identityPoolId,
+      });
+
+      const identityResponse = await cognitoClient.send(getIdCommand);
+
+      if (!identityResponse.IdentityId) {
+        addResult({
+          step: '3. Identity ID 획득',
+          status: 'error',
+          message: 'Identity ID를 획득할 수 없습니다'
+        });
+        return;
+      }
+
+      addResult({
+        step: '3. Identity ID 획득',
+        status: 'success',
+        message: 'Identity ID 획득 완료',
+        data: { identityId: identityResponse.IdentityId }
+      });
+
+      // 4단계: 자격증명 획득
+      addResult({
+        step: '4. 자격증명 획득',
+        status: 'pending',
+        message: 'AWS 자격증명 요청 중...'
+      });
+
+      const getCredentialsCommand = new GetCredentialsForIdentityCommand({
+        IdentityId: identityResponse.IdentityId,
+      });
+
+      const credentialsResponse = await cognitoClient.send(getCredentialsCommand);
+
+      if (!credentialsResponse.Credentials) {
+        addResult({
+          step: '4. 자격증명 획득',
+          status: 'error',
+          message: 'AWS 자격증명을 획득할 수 없습니다'
+        });
+        return;
+      }
+
+      addResult({
+        step: '4. 자격증명 획득',
+        status: 'success',
+        message: 'AWS 자격증명 획득 완료',
+        data: {
+          accessKeyId: credentialsResponse.Credentials.AccessKeyId,
+          secretAccessKey: credentialsResponse.Credentials.SecretKey?.slice(0, 10) + '...',
+          sessionToken: credentialsResponse.Credentials.SessionToken?.slice(0, 20) + '...',
+          expiration: credentialsResponse.Credentials.Expiration?.toISOString()
+        }
+      });
+
+      addResult({
+        step: '✅ 게스트 접근 테스트 완료',
+        status: 'success',
+        message: 'Cognito Identity Pool 게스트 접근이 정상적으로 작동합니다!'
+      });
+
+    } catch (error) {
+      addResult({
+        step: '❌ 게스트 접근 테스트 실패',
+        status: 'error',
+        message: `오류 발생: ${error instanceof Error ? error.message : '알 수 없는 오류'}`,
+        data: error
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const testKMSAccess = async () => {
+    setIsLoading(true);
+    clearResults();
+
+    try {
+      // 1단계: 환경변수 확인
+      addResult({
+        step: '1. KMS 환경변수 확인',
+        status: 'pending',
+        message: 'KMS 환경변수 확인 중...'
+      });
+
+      const region = import.meta.env.VITE_AWS_REGION;
+      const kmsKeyId = import.meta.env.VITE_KMS_KEY_ID;
+      const kmsKeyArn = import.meta.env.VITE_KMS_KEY_ARN;
+
+      if (!region || !kmsKeyId) {
+        addResult({
+          step: '1. KMS 환경변수 확인',
+          status: 'error',
+          message: 'KMS 환경변수가 누락되었습니다',
+          data: { region, kmsKeyId, kmsKeyArn }
+        });
+        return;
+      }
+
+      addResult({
+        step: '1. KMS 환경변수 확인',
+        status: 'success',
+        message: 'KMS 환경변수 확인 완료',
+        data: { region, kmsKeyId, kmsKeyArn }
+      });
+
+      // 2단계: Cognito 자격증명 획득
+      addResult({
+        step: '2. Cognito 자격증명 획득',
+        status: 'pending',
+        message: 'Cognito 자격증명 획득 중...'
+      });
+
+      let credentials;
+      
+      // IAM 사용자 방식만 사용
+      const accessKeyId = import.meta.env.VITE_AWS_ACCESS_KEY_ID;
+      const secretAccessKey = import.meta.env.VITE_AWS_SECRET_ACCESS_KEY;
+      const frontendRoleArn = import.meta.env.VITE_FRONTEND_ROLE_ARN;
+
+      if (!accessKeyId || !secretAccessKey || !frontendRoleArn) {
+        addResult({
+          step: '2. Cognito 자격증명 획득',
+          status: 'error',
+          message: 'IAM 환경변수가 누락되었습니다'
+        });
+        return;
+      }
+
+      const stsClient = new STSClient({
+        region,
+        credentials: { accessKeyId, secretAccessKey }
+      });
+
+      const assumeRoleResponse = await stsClient.send(new AssumeRoleCommand({
+        RoleArn: frontendRoleArn,
+        RoleSessionName: 'kms-test-session',
+        DurationSeconds: 3600
+      }));
+
+      credentials = assumeRoleResponse.Credentials;
+
+      if (!credentials) {
+        addResult({
+          step: '2. Cognito 자격증명 획득',
+          status: 'error',
+          message: 'AWS 자격증명을 획득할 수 없습니다'
+        });
+        return;
+      }
+
+      addResult({
+        step: '2. Cognito 자격증명 획득',
+        status: 'success',
+        message: 'AWS 자격증명 획득 완료',
+        data: {
+          accessKeyId: credentials.AccessKeyId?.slice(0, 8) + '...',
+          expiration: credentials.Expiration?.toISOString(),
+          authMode: authMode,
+          note: 'IAM 사용자 - Frontend 역할 사용'
+        }
+      });
+
+      // 3단계: KMS 클라이언트 생성 및 공개키 조회
+      addResult({
+        step: '3. KMS 공개키 조회',
+        status: 'pending',
+        message: 'KMS 공개키 조회 중...'
+      });
+
+      const kmsClient = new KMSClient({
+        region,
+        credentials: {
+          accessKeyId: credentials.AccessKeyId!,
+          secretAccessKey: (credentials as any).SecretKey || (credentials as any).SecretAccessKey,
+          sessionToken: credentials.SessionToken!
+        }
+      });
+
+      const publicKeyResponse = await kmsClient.send(new GetPublicKeyCommand({
+        KeyId: kmsKeyId
+      }));
+
+      if (!publicKeyResponse.PublicKey) {
+        addResult({
+          step: '3. KMS 공개키 조회',
+          status: 'error',
+          message: 'KMS 공개키를 조회할 수 없습니다'
+        });
+        return;
+      }
+
+      // 공개키를 저장 (JWE 테스트에서 사용)
+      const publicKeyArray = new Uint8Array(publicKeyResponse.PublicKey);
+      setLastPublicKey(publicKeyArray);
+      
+      // 공개키를 Base64로 인코딩 (브라우저 환경에서 사용 가능한 방법)
+      const publicKeyBase64 = btoa(String.fromCharCode(...publicKeyArray));
+
+      addResult({
+        step: '3. KMS 공개키 조회',
+        status: 'success',
+        message: 'KMS 공개키 조회 완료',
+        data: {
+          keyId: publicKeyResponse.KeyId,
+          keyUsage: publicKeyResponse.KeyUsage,
+          keySpec: publicKeyResponse.KeySpec,
+          encryptionAlgorithms: publicKeyResponse.EncryptionAlgorithms,
+          publicKeyLength: publicKeyResponse.PublicKey.length,
+          publicKeyPreview: publicKeyBase64.slice(0, 100) + '...'
+        }
+      });
+
+      addResult({
+        step: '✅ KMS 테스트 완료',
+        status: 'success',
+        message: 'KMS 공개키 조회가 정상적으로 작동합니다!'
+      });
+
+    } catch (error) {
+      addResult({
+        step: '❌ KMS 테스트 실패',
+        status: 'error',
+        message: `오류 발생: ${error instanceof Error ? error.message : '알 수 없는 오류'}`,
+        data: error
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const testJWEGeneration = async () => {
+    setIsLoading(true);
+    clearResults();
+
+    try {
+      // 1단계: 공개키 확인
+      addResult({
+        step: '1. KMS 공개키 확인',
+        status: 'pending',
+        message: 'KMS 공개키 확인 중...'
+      });
+
+      if (!lastPublicKey) {
+        addResult({
+          step: '1. KMS 공개키 확인',
+          status: 'error',
+          message: '먼저 KMS 공개키 조회 테스트를 실행해주세요.'
+        });
+        return;
+      }
+
+      addResult({
+        step: '1. KMS 공개키 확인',
+        status: 'success',
+        message: 'KMS 공개키 확인 완료',
+        data: {
+          publicKeyLength: lastPublicKey.length,
+          publicKeyType: 'RSA_2048'
+        }
+      });
+
+      // 2단계: 테스트 페이로드 생성
+      addResult({
+        step: '2. 테스트 페이로드 생성',
+        status: 'pending',
+        message: '암호화할 페이로드 생성 중...'
+      });
+
+      const testPayload = createTestPayload('test-user-123');
+      
+      addResult({
+        step: '2. 테스트 페이로드 생성',
+        status: 'success',
+        message: '테스트 페이로드 생성 완료',
+        data: testPayload
+      });
+
+      // 3단계: JWE 토큰 생성
+      addResult({
+        step: '3. JWE 토큰 생성',
+        status: 'pending',
+        message: 'JWE 토큰 생성 중...'
+      });
+
+      const result = await generateJWEToken(lastPublicKey, testPayload);
+
+      if (result.success) {
+        addResult({
+          step: '3. JWE 토큰 생성',
+          status: 'success',
+          message: 'JWE 토큰 생성 완료',
+          data: {
+            tokenLength: result.token?.length,
+            tokenPreview: result.token?.slice(0, 100) + '...',
+            details: result.details
+          }
+        });
+
+        // 4단계: 토큰 구조 분석
+        addResult({
+          step: '4. JWE 토큰 구조 분석',
+          status: 'pending',
+          message: 'JWE 토큰 구조 분석 중...'
+        });
+
+        const tokenParts = result.token?.split('.');
+        if (tokenParts && tokenParts.length === 5) {
+          addResult({
+            step: '4. JWE 토큰 구조 분석',
+            status: 'success',
+            message: 'JWE 토큰 구조 분석 완료',
+            data: {
+              structure: 'Compact Serialization Format',
+              parts: [
+                { name: 'Protected Header', length: tokenParts[0].length },
+                { name: 'Encrypted Key', length: tokenParts[1].length },
+                { name: 'Initialization Vector', length: tokenParts[2].length },
+                { name: 'Ciphertext', length: tokenParts[3].length },
+                { name: 'Authentication Tag', length: tokenParts[4].length }
+              ],
+              totalParts: tokenParts.length
+            }
+          });
+        }
+
+        // 토큰 저장
+        setLastJWEToken(result.token!);
+        
+        addResult({
+          step: '✅ JWE 토큰 생성 테스트 완료',
+          status: 'success',
+          message: 'JWE 토큰이 정상적으로 생성되었습니다!',
+          data: {
+            fullToken: result.token
+          }
+        });
+
+      } else {
+        addResult({
+          step: '3. JWE 토큰 생성',
+          status: 'error',
+          message: `JWE 토큰 생성 실패: ${result.error}`,
+          data: result.details
+        });
+      }
+
+    } catch (error) {
+      addResult({
+        step: '❌ JWE 토큰 생성 테스트 실패',
+        status: 'error',
+        message: `오류 발생: ${error instanceof Error ? error.message : '알 수 없는 오류'}`,
+        data: error
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const testIntegration = async () => {
+    setIsLoading(true);
+    clearResults();
+    let publicKey: Uint8Array | null = null;
+    let jweToken: string | null = null;
+
+    try {
+      // 단계 1: Cognito 인증
+      addResult({
+        step: '[통합] 1. Cognito 인증',
+        status: 'pending',
+        message: 'Cognito Identity Pool 연결 중...'
+      });
+
+      const identityPoolId = import.meta.env.VITE_COGNITO_IDENTITY_POOL_ID;
+      const region = import.meta.env.VITE_AWS_REGION;
+      let credentials;
+
+      // IAM 사용자 인증만 사용
+      const accessKeyId = import.meta.env.VITE_AWS_ACCESS_KEY_ID;
+      const secretAccessKey = import.meta.env.VITE_AWS_SECRET_ACCESS_KEY;
+      const frontendRoleArn = import.meta.env.VITE_FRONTEND_ROLE_ARN;
+
+      const stsClient = new STSClient({
+        region,
+        credentials: { accessKeyId, secretAccessKey }
+      });
+
+      const assumeRoleResponse = await stsClient.send(new AssumeRoleCommand({
+        RoleArn: frontendRoleArn,
+        RoleSessionName: 'integration-test-session',
+        DurationSeconds: 3600
+      }));
+      credentials = assumeRoleResponse.Credentials;
+
+      if (!credentials) {
+        throw new Error('AWS 자격증명 획득 실패');
+      }
+
+      addResult({
+        step: '[통합] 1. Cognito 인증',
+        status: 'success',
+        message: 'Cognito 인증 성공',
+        data: {
+          authMode,
+          accessKeyId: credentials.AccessKeyId?.slice(0, 8) + '...',
+          expiration: credentials.Expiration?.toISOString()
+        }
+      });
+
+      // 단계 2: KMS 공개키 조회
+      addResult({
+        step: '[통합] 2. KMS 공개키 조회',
+        status: 'pending',
+        message: 'KMS 공개키 조회 중...'
+      });
+
+      const kmsKeyId = import.meta.env.VITE_KMS_KEY_ID;
+      const kmsClient = new KMSClient({
+        region,
+        credentials: {
+          accessKeyId: credentials.AccessKeyId!,
+          secretAccessKey: (credentials as any).SecretKey || (credentials as any).SecretAccessKey,
+          sessionToken: credentials.SessionToken!
+        }
+      });
+
+      const publicKeyResponse = await kmsClient.send(new GetPublicKeyCommand({
+        KeyId: kmsKeyId
+      }));
+
+      if (!publicKeyResponse.PublicKey) {
+        throw new Error('KMS 공개키 조회 실패');
+      }
+
+      publicKey = new Uint8Array(publicKeyResponse.PublicKey);
+      setLastPublicKey(publicKey);
+
+      addResult({
+        step: '[통합] 2. KMS 공개키 조회',
+        status: 'success',
+        message: 'KMS 공개키 조회 성공',
+        data: {
+          keyId: publicKeyResponse.KeyId,
+          keySpec: publicKeyResponse.KeySpec,
+          keyUsage: publicKeyResponse.KeyUsage,
+          publicKeyLength: publicKey.length
+        }
+      });
+
+      // 단계 3: JWE 토큰 생성
+      addResult({
+        step: '[통합] 3. JWE 토큰 생성',
+        status: 'pending',
+        message: 'JWE 토큰 생성 중...'
+      });
+
+      const testPayload = createTestPayload('integration-test-user');
+      const jweResult = await generateJWEToken(publicKey, testPayload);
+
+      if (!jweResult.success || !jweResult.token) {
+        throw new Error(jweResult.error || 'JWE 토큰 생성 실패');
+      }
+
+      jweToken = jweResult.token;
+      setLastJWEToken(jweToken);
+
+      addResult({
+        step: '[통합] 3. JWE 토큰 생성',
+        status: 'success',
+        message: 'JWE 토큰 생성 성공',
+        data: {
+          tokenLength: jweToken.length,
+          tokenPreview: jweToken.slice(0, 50) + '...',
+          details: jweResult.details
+        }
+      });
+
+      // 단계 4: 토큰 검증
+      addResult({
+        step: '[통합] 4. 토큰 검증',
+        status: 'pending',
+        message: 'JWE 토큰 구조 검증 중...'
+      });
+
+      const tokenParts = jweToken.split('.');
+      if (tokenParts.length !== 5) {
+        throw new Error(`잘못된 JWE 토큰 형식: ${tokenParts.length}개 부분 (예상: 5개)`);
+      }
+
+      // Protected Header 디코딩
+      const protectedHeader = JSON.parse(atob(tokenParts[0]));
+
+      addResult({
+        step: '[통합] 4. 토큰 검증',
+        status: 'success',
+        message: 'JWE 토큰 검증 성공',
+        data: {
+          structure: 'Compact Serialization (5 parts)',
+          protectedHeader,
+          parts: [
+            { name: 'Protected Header', length: tokenParts[0].length },
+            { name: 'Encrypted Key', length: tokenParts[1].length },
+            { name: 'Initialization Vector', length: tokenParts[2].length },
+            { name: 'Ciphertext', length: tokenParts[3].length },
+            { name: 'Authentication Tag', length: tokenParts[4].length }
+          ]
+        }
+      });
+
+      // 성공 메시지
+      addResult({
+        step: '✅ 통합 테스트 완료',
+        status: 'success',
+        message: '모든 단계가 성공적으로 완료되었습니다!',
+        data: {
+          summary: {
+            authMode,
+            cognitoIdentityPool: identityPoolId,
+            kmsKeyId: import.meta.env.VITE_KMS_KEY_ID,
+            jweTokenLength: jweToken.length,
+            fullToken: jweToken
+          }
+        }
+      });
+
+    } catch (error) {
+      addResult({
+        step: '❌ 통합 테스트 실패',
+        status: 'error',
+        message: `오류 발생: ${error instanceof Error ? error.message : '알 수 없는 오류'}`,
+        data: error
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleTestStart = () => {
+    if (testMode === 'cognito') {
+      if (authMode === 'iam') {
+        testIAMAuthentication();
+      } else {
+        testProfileAuthentication();
+      }
+    } else if (testMode === 'kms') {
+      testKMSAccess();
+    } else if (testMode === 'jwe') {
+      testJWEGeneration();
+    } else if (testMode === 'chat') {
+      testChatJWE();
+    } else {
+      testIntegration();
+    }
+  };
+
+  const testChatJWE = async () => {
+    setIsLoading(true);
+    clearResults();
+
+    try {
+      // authMode가 'profile'인 경우 'iam'으로 변환
+      const jweAuthMode = authMode === 'profile' ? 'iam' : authMode;
+      
+      // 1단계: 채팅 JWE 서비스 설정 확인
+      addResult({
+        step: '1. 채팅 JWE 서비스 설정 확인',
+        status: 'pending',
+        message: '채팅 JWE 서비스 설정 확인 중...'
+      });
+
+      const config = chatJWEService.getCurrentConfig();
+      
+      addResult({
+        step: '1. 채팅 JWE 서비스 설정 확인',
+        status: 'success',
+        message: '채팅 JWE 서비스 설정 확인 완료',
+        data: {
+          clientId: config.clientId,
+          appId: config.appId,
+          authMode: jweAuthMode
+        }
+      });
+
+      // 2단계: JWE 토큰 생성 테스트
+      addResult({
+        step: '2. 채팅용 JWE 토큰 생성',
+        status: 'pending',
+        message: 'client_id와 app_id가 포함된 JWE 토큰 생성 중...'
+      });
+
+      const jweResult = await chatJWEService.createChatJWEToken({ authMode: jweAuthMode });
+      
+      if (!jweResult.success || !jweResult.token) {
+        addResult({
+          step: '2. 채팅용 JWE 토큰 생성',
+          status: 'error',
+          message: `JWE 토큰 생성 실패: ${jweResult.error}`,
+          data: jweResult.details
+        });
+        return;
+      }
+
+      addResult({
+        step: '2. 채팅용 JWE 토큰 생성',
+        status: 'success',
+        message: '채팅용 JWE 토큰 생성 성공',
+        data: {
+          tokenLength: jweResult.token.length,
+          tokenPreview: jweResult.token.slice(0, 50) + '...',
+          details: jweResult.details
+        }
+      });
+
+      // 3단계: 채팅 API 호출 테스트
+      addResult({
+        step: '3. JWE 헤더를 포함한 채팅 API 호출',
+        status: 'pending',
+        message: 'JWE 토큰이 포함된 채팅 메시지 전송 중...'
+      });
+
+      const testMessage = 'JWE 테스트 메시지입니다.';
+      const testUserId = `test-user-${Date.now()}`;
+      
+      // 실제 채팅 API 호출 (JWE 헤더 포함)
+      const chatResponse = await sendChatMessage(testMessage, testUserId);
+
+      addResult({
+        step: '3. JWE 헤더를 포함한 채팅 API 호출',
+        status: 'success',
+        message: '채팅 API 호출 성공',
+        data: {
+          request: {
+            message: testMessage,
+            userId: testUserId,
+            jweHeaderIncluded: true
+          },
+          response: {
+            responseLength: chatResponse.response?.length || 0,
+            responsePreview: chatResponse.response?.slice(0, 100) + '...',
+            timestamp: chatResponse.timestamp,
+            tool: chatResponse.tool
+          }
+        }
+      });
+
+      // 성공 메시지
+      addResult({
+        step: '✅ 채팅 JWE 통합 테스트 완료',
+        status: 'success',
+        message: 'JWE 토큰이 포함된 채팅 API 호출이 성공했습니다!',
+        data: {
+          summary: {
+            jweTokenGenerated: true,
+            apiCallSuccessful: true,
+            client_id: config.clientId,
+            app_id: config.appId,
+            authMode: jweAuthMode,
+            testMessage,
+            responseReceived: !!chatResponse.response
+          }
+        }
+      });
+
+    } catch (error) {
+      addResult({
+        step: '❌ 채팅 JWE 테스트 실패',
+        status: 'error',
+        message: `오류 발생: ${error instanceof Error ? error.message : '알 수 없는 오류'}`,
+        data: error
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="w-full mx-auto p-6 bg-white rounded-lg shadow-lg">
+
+      <div className="mb-6">
+        <div className="flex items-center gap-4 mb-4">
+          <label className="text-sm font-medium text-gray-700">테스트 모드:</label>
+          <div className="flex gap-2">
+            <button
+              onClick={() => setTestMode('cognito')}
+              className={`px-4 py-2 rounded-lg text-sm font-medium ${
+                testMode === 'cognito'
+                  ? 'bg-green-600 text-white'
+                  : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+              }`}
+            >
+              Cognito 인증
+            </button>
+            <button
+              onClick={() => setTestMode('kms')}
+              className={`px-4 py-2 rounded-lg text-sm font-medium ${
+                testMode === 'kms'
+                  ? 'bg-green-600 text-white'
+                  : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+              }`}
+            >
+              KMS 공개키 조회
+            </button>
+            <button
+              onClick={() => setTestMode('jwe')}
+              className={`px-4 py-2 rounded-lg text-sm font-medium ${
+                testMode === 'jwe'
+                  ? 'bg-purple-600 text-white'
+                  : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+              }`}
+            >
+              JWE 토큰 생성
+            </button>
+            <button
+              onClick={() => setTestMode('integration')}
+              className={`px-4 py-2 rounded-lg text-sm font-medium ${
+                testMode === 'integration'
+                  ? 'bg-indigo-600 text-white'
+                  : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+              }`}
+            >
+              통합 테스트
+            </button>
+            <button
+              onClick={() => setTestMode('chat')}
+              className={`px-4 py-2 rounded-lg text-sm font-medium ${
+                testMode === 'chat'
+                  ? 'bg-pink-600 text-white'
+                  : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+              }`}
+            >
+              채팅 JWE 테스트
+            </button>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-4 mb-4">
+          <label className="text-sm font-medium text-gray-700">인증 방식:</label>
+          <div className="flex gap-2">
+            <button
+              onClick={() => setAuthMode('iam')}
+              className={`px-4 py-2 rounded-lg text-sm font-medium ${
+                authMode === 'iam'
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+              }`}
+            >
+              IAM 환경변수
+            </button>
+            <button
+              onClick={() => setAuthMode('profile')}
+              className={`px-4 py-2 rounded-lg text-sm font-medium ${
+                authMode === 'profile'
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+              }`}
+            >
+              AWS Profile
+            </button>
+          </div>
+        </div>
+
+        <div className="flex gap-4">
+          <button
+            onClick={handleTestStart}
+            disabled={isLoading}
+            className={`px-6 py-3 rounded-lg font-semibold ${
+              isLoading
+                ? 'bg-gray-400 cursor-not-allowed'
+                : testMode === 'cognito'
+                  ? 'bg-blue-600 hover:bg-blue-700 text-white'
+                  : 'bg-green-600 hover:bg-green-700 text-white'
+            }`}
+          >
+            {isLoading ? '테스트 진행 중...' : `${testMode === 'cognito' ? 'Cognito 인증' : testMode === 'kms' ? 'KMS 공개키 조회' : testMode === 'jwe' ? 'JWE 토큰 생성' : testMode === 'chat' ? '채팅 JWE' : '통합'} 테스트 시작`}
+          </button>
+          
+          {results.length > 0 && (
+            <button
+              onClick={clearResults}
+              className="px-4 py-2 bg-gray-500 text-white rounded-lg hover:bg-gray-600"
+            >
+              결과 초기화
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="test-results space-y-4 overflow-y-auto border border-gray-200 rounded-lg p-4 bg-gray-50" style={{ maxHeight: '450px' }}>
+        {results.length === 0 ? (
+          <div className="text-center text-gray-500 py-8">
+            테스트 결과가 여기에 표시됩니다.
+          </div>
+        ) : (
+          results.map((result, index) => (
+          <div
+            key={index}
+            className={`p-4 rounded-lg border-l-4 ${
+              result.status === 'success'
+                ? 'bg-green-50 border-green-500'
+                : result.status === 'error'
+                ? 'bg-red-50 border-red-500'
+                : 'bg-blue-50 border-blue-500'
+            }`}
+          >
+            <div className="flex items-center mb-2">
+              <span className={`w-3 h-3 rounded-full mr-3 ${
+                result.status === 'success'
+                  ? 'bg-green-500'
+                  : result.status === 'error'
+                  ? 'bg-red-500'
+                  : 'bg-blue-500'
+              }`}></span>
+              <h3 className="font-semibold text-gray-800">{result.step}</h3>
+            </div>
+            <p className="text-gray-700 mb-2">{result.message}</p>
+            {result.data && (
+              <pre className="text-sm bg-gray-100 p-2 rounded overflow-x-auto">
+                {JSON.stringify(result.data, null, 2)}
+              </pre>
+            )}
+          </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/dev/pages/JWETestPage.tsx
+++ b/src/dev/pages/JWETestPage.tsx
@@ -1,0 +1,28 @@
+/**
+ * JWE 테스트 전용 페이지
+ * 단계별로 테스트하면서 JWE 구현을 진행합니다.
+ */
+
+import React from 'react';
+import { CognitoTestPage } from './CognitoTestPage';
+
+export const JWETestPage: React.FC = () => {
+
+  return (
+    <div className="w-full bg-gray-50 py-8 pb-96">
+      <div className="container mx-auto px-4 max-w-6xl">
+        <div className="mb-8 text-center">
+          <h1 className="text-3xl font-bold text-gray-800 mb-2">
+            JWE 구현 테스트
+          </h1>
+        </div>
+        
+        <CognitoTestPage />
+        
+        {/* 스크롤을 위한 여백 */}
+        <div className="h-96"></div>
+      </div>
+    </div>
+  );
+};
+

--- a/src/dev/pages/index.ts
+++ b/src/dev/pages/index.ts
@@ -1,0 +1,6 @@
+/**
+ * 개발/테스트용 페이지 export
+ */
+
+export { CognitoTestPage } from './CognitoTestPage';
+export { JWETestPage } from './JWETestPage';

--- a/src/services/api/chat.ts
+++ b/src/services/api/chat.ts
@@ -1,4 +1,5 @@
 import { fetchApi } from './index';
+import { chatJWEService } from '../jwe/chatJWEService';
 
 export interface ChatMessage {
   id: string;
@@ -22,13 +23,50 @@ export interface ChatResponse {
 }
 
 export const sendChatMessage = async (message: string, userId: string): Promise<ChatResponse> => {
-  return fetchApi('/students/chat', {
-    method: 'POST',
-    body: JSON.stringify({
-      userId,
-      message,
-    }),
-  });
+  try {
+    // JWE 토큰 생성 (client_id, app_id 암호화)
+    console.log('채팅 메시지 전송 시작 - JWE 토큰 생성 중...');
+    const jweResult = await chatJWEService.createChatJWEToken();
+    
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+
+    // JWE 토큰이 성공적으로 생성된 경우 헤더에 추가
+    if (jweResult.success && jweResult.token) {
+      headers['X-JWE-Token'] = jweResult.token;
+      console.log('JWE 토큰이 헤더에 추가됨:', {
+        client_id: jweResult.details?.client_id,
+        app_id: jweResult.details?.app_id,
+        tokenLength: jweResult.details?.tokenLength
+      });
+    } else {
+      // JWE 토큰 생성 실패 시 경고 로그 (채팅은 계속 진행)
+      console.warn('JWE 토큰 생성 실패, 토큰 없이 요청 진행:', jweResult.error);
+    }
+
+    return fetchApi('/students/chat', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        userId,
+        message,
+      }),
+    });
+
+  } catch (error) {
+    console.error('채팅 메시지 전송 중 오류:', error);
+    
+    // JWE 토큰 생성 실패해도 기본 채팅 요청은 진행 (폴백)
+    console.log('JWE 토큰 없이 기본 채팅 요청 시도');
+    return fetchApi('/students/chat', {
+      method: 'POST',
+      body: JSON.stringify({
+        userId,
+        message,
+      }),
+    });
+  }
 };
 
 export const getChatHistory = async (userId: string): Promise<ChatMessage[]> => {

--- a/src/services/jwe/chatJWEService.ts
+++ b/src/services/jwe/chatJWEService.ts
@@ -1,0 +1,147 @@
+/**
+ * 채팅 API 전용 JWE 서비스
+ * LLM 채팅 요청 시 client_id와 app_id를 안전하게 전송하기 위한 JWE 토큰 생성
+ */
+
+import { JWEService, createJWEService } from './jweService';
+import { ChatJWEPayload, JWEHeaderResult, JWETokenOptions } from '../../types/jwe';
+
+export class ChatJWEService {
+  private jweServiceIAM: JWEService;
+  private clientId: string;
+  private appId: string;
+
+  constructor(clientId?: string, appId?: string) {
+    // IAM 모드의 JWE 서비스 생성
+    this.jweServiceIAM = createJWEService('iam');
+    this.clientId = clientId || import.meta.env.VITE_CLIENT_ID || 'default_client';
+    this.appId = appId || import.meta.env.VITE_APP_ID || 'ai-navi-chat';
+  }
+
+  /**
+   * 채팅 요청용 JWE 토큰 생성
+   * @param options 토큰 생성 옵션
+   * @returns JWE 헤더 생성 결과
+   */
+  async createChatJWEToken(options: JWETokenOptions = {}): Promise<JWEHeaderResult> {
+    try {
+      // 채팅용 페이로드 생성
+      const payload: ChatJWEPayload = {
+        client_id: this.clientId,
+        app_id: this.appId,
+        request_type: 'chat',
+        userId: `chat-user-${Date.now()}`,
+        sessionId: `chat-session-${Date.now()}`,
+        timestamp: Date.now(),
+        // 만료시간 설정 (기본 1시간)
+        exp: Math.floor(Date.now() / 1000) + (options.expiresIn || 3600),
+        // 발급시간
+        iat: Math.floor(Date.now() / 1000),
+        // 사용 용도
+        purpose: 'chat-api-authentication'
+      };
+
+      // IAM 모드로 JWE 서비스 사용
+      const authMode = options.authMode || 'iam';
+      const jweService = this.jweServiceIAM;
+
+      console.log('채팅 JWE 토큰 생성 시작:', {
+        client_id: this.clientId,
+        app_id: this.appId,
+        authMode
+      });
+
+      // JWE 토큰 생성
+      const result = await jweService.createJWEToken(payload);
+
+      if (result.success && result.token) {
+        console.log('채팅 JWE 토큰 생성 성공:', {
+          tokenLength: result.token.length,
+          client_id: this.clientId,
+          app_id: this.appId
+        });
+
+        return {
+          success: true,
+          token: result.token,
+          details: {
+            client_id: this.clientId,
+            app_id: this.appId,
+            tokenLength: result.token.length,
+            authMode
+          }
+        };
+      } else {
+        console.error('채팅 JWE 토큰 생성 실패:', result.error);
+        
+        return {
+          success: false,
+          error: result.error || 'JWE 토큰 생성 실패',
+          details: {
+            client_id: this.clientId,
+            app_id: this.appId,
+            authMode
+          }
+        };
+      }
+
+    } catch (error) {
+      console.error('채팅 JWE 서비스 오류:', error);
+      
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : '알 수 없는 오류',
+        details: {
+          client_id: this.clientId,
+          app_id: this.appId,
+          authMode
+        }
+      };
+    }
+  }
+
+  /**
+   * client_id 업데이트
+   * @param clientId 새로운 클라이언트 ID
+   */
+  updateClientId(clientId: string): void {
+    this.clientId = clientId;
+    console.log('클라이언트 ID 업데이트:', clientId);
+  }
+
+  /**
+   * app_id 업데이트
+   * @param appId 새로운 앱 ID
+   */
+  updateAppId(appId: string): void {
+    this.appId = appId;
+    console.log('앱 ID 업데이트:', appId);
+  }
+
+  /**
+   * 현재 설정 정보 조회
+   * @returns 현재 클라이언트 ID와 앱 ID
+   */
+  getCurrentConfig(): { clientId: string; appId: string } {
+    return {
+      clientId: this.clientId,
+      appId: this.appId
+    };
+  }
+
+  /**
+   * JWE 서비스 캐시 초기화
+   */
+  clearCache(): void {
+    this.jweServiceIAM.clearCache();
+    console.log('채팅 JWE 서비스 캐시 초기화됨');
+  }
+}
+
+// 기본 채팅 JWE 서비스 인스턴스 (IAM 모드)
+export const chatJWEService = new ChatJWEService();
+
+// IAM 인증용 채팅 JWE 서비스 인스턴스 생성 함수
+export function createChatJWEServiceWithIAM(clientId?: string, appId?: string): ChatJWEService {
+  return new ChatJWEService(clientId, appId);
+}

--- a/src/services/jwe/index.ts
+++ b/src/services/jwe/index.ts
@@ -1,0 +1,19 @@
+/**
+ * JWE 서비스 통합 export
+ */
+
+export { JWEService, createJWEService } from './jweService';
+export type { JWEServiceConfig, JWEServiceResult } from './jweService';
+
+export { generateJWEToken, createTestPayload, convertToPEM } from './jweTokenGenerator';
+export type { JWEPayload, JWEGenerationResult } from './jweTokenGenerator';
+
+// 간편 사용을 위한 기본 JWE 서비스 인스턴스
+import { createJWEService } from './jweService';
+
+// IAM 인증용 기본 인스턴스
+export const jweServiceIAM = createJWEService('iam');
+
+// 채팅 전용 JWE 서비스
+export { ChatJWEService, chatJWEService, createChatJWEServiceWithIAM } from './chatJWEService';
+export type { ChatJWEPayload, JWEHeaderResult, JWETokenOptions } from '../types/jwe';

--- a/src/services/jwe/jweService.ts
+++ b/src/services/jwe/jweService.ts
@@ -1,0 +1,209 @@
+/**
+ * JWE 서비스
+ * Cognito, KMS, JWE 토큰 생성을 통합한 서비스
+ */
+
+import { CognitoIdentityClient, GetIdCommand, GetCredentialsForIdentityCommand } from '@aws-sdk/client-cognito-identity';
+import { STSClient, AssumeRoleCommand } from '@aws-sdk/client-sts';
+import { KMSClient, GetPublicKeyCommand } from '@aws-sdk/client-kms';
+import { generateJWEToken, JWEPayload } from './jweTokenGenerator';
+
+export interface JWEServiceConfig {
+  identityPoolId: string;
+  region: string;
+  kmsKeyId: string;
+  authMode?: 'guest' | 'iam';
+  iamCredentials?: {
+    accessKeyId: string;
+    secretAccessKey: string;
+    frontendRoleArn: string;
+  };
+}
+
+export interface JWEServiceResult {
+  success: boolean;
+  token?: string;
+  error?: string;
+  details?: {
+    authMode: string;
+    identityId?: string;
+    tokenLength?: number;
+    publicKeyId?: string;
+  };
+}
+
+export class JWEService {
+  private config: JWEServiceConfig;
+  private cachedPublicKey: Uint8Array | null = null;
+  private publicKeyCacheTime: number = 0;
+  private readonly CACHE_DURATION = 3600000; // 1시간
+
+  constructor(config: JWEServiceConfig) {
+    this.config = config;
+  }
+
+  /**
+   * JWE 토큰 생성
+   * @param payload 암호화할 페이로드
+   * @returns JWE 토큰 생성 결과
+   */
+  async createJWEToken(payload: JWEPayload): Promise<JWEServiceResult> {
+    try {
+      // 1. AWS 자격증명 획득
+      const credentials = await this.getAWSCredentials();
+      if (!credentials) {
+        return {
+          success: false,
+          error: 'AWS 자격증명 획득 실패'
+        };
+      }
+
+      // 2. KMS 공개키 조회 (캐시 확인)
+      const publicKey = await this.getKMSPublicKey(credentials);
+      if (!publicKey) {
+        return {
+          success: false,
+          error: 'KMS 공개키 조회 실패'
+        };
+      }
+
+      // 3. JWE 토큰 생성
+      const jweResult = await generateJWEToken(publicKey, payload);
+      
+      if (!jweResult.success || !jweResult.token) {
+        return {
+          success: false,
+          error: jweResult.error || 'JWE 토큰 생성 실패',
+          details: jweResult.details
+        };
+      }
+
+      return {
+        success: true,
+        token: jweResult.token,
+        details: {
+          authMode: this.config.authMode || 'guest',
+          tokenLength: jweResult.token.length,
+          publicKeyId: this.config.kmsKeyId,
+          ...jweResult.details
+        }
+      };
+
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : '알 수 없는 오류',
+        details: { authMode: this.config.authMode || 'guest' }
+      };
+    }
+  }
+
+  /**
+   * AWS 자격증명 획득
+   * @returns AWS 자격증명
+   */
+  private async getAWSCredentials(): Promise<any> {
+    if (this.config.authMode === 'iam' && this.config.iamCredentials) {
+      // IAM 사용자 인증
+      const stsClient = new STSClient({
+        region: this.config.region,
+        credentials: {
+          accessKeyId: this.config.iamCredentials.accessKeyId,
+          secretAccessKey: this.config.iamCredentials.secretAccessKey,
+        }
+      });
+
+      const assumeRoleResponse = await stsClient.send(new AssumeRoleCommand({
+        RoleArn: this.config.iamCredentials.frontendRoleArn,
+        RoleSessionName: 'jwe-service-session',
+        DurationSeconds: 3600
+      }));
+
+      return assumeRoleResponse.Credentials;
+    } else {
+      // 게스트 접근 (기본값)
+      const cognitoClient = new CognitoIdentityClient({
+        region: this.config.region,
+      });
+
+      const identityResponse = await cognitoClient.send(new GetIdCommand({
+        IdentityPoolId: this.config.identityPoolId,
+      }));
+
+      const credentialsResponse = await cognitoClient.send(new GetCredentialsForIdentityCommand({
+        IdentityId: identityResponse.IdentityId!,
+      }));
+
+      return credentialsResponse.Credentials;
+    }
+  }
+
+  /**
+   * KMS 공개키 조회 (캐시 지원)
+   * @param credentials AWS 자격증명
+   * @returns KMS 공개키
+   */
+  private async getKMSPublicKey(credentials: any): Promise<Uint8Array | null> {
+    // 캐시 확인
+    const now = Date.now();
+    if (this.cachedPublicKey && (now - this.publicKeyCacheTime) < this.CACHE_DURATION) {
+      console.log('KMS 공개키 캐시 사용');
+      return this.cachedPublicKey;
+    }
+
+    // KMS에서 공개키 조회
+    const kmsClient = new KMSClient({
+      region: this.config.region,
+      credentials: {
+        accessKeyId: credentials.AccessKeyId!,
+        secretAccessKey: credentials.SecretKey || credentials.SecretAccessKey,
+        sessionToken: credentials.SessionToken!
+      }
+    });
+
+    const publicKeyResponse = await kmsClient.send(new GetPublicKeyCommand({
+      KeyId: this.config.kmsKeyId
+    }));
+
+    if (!publicKeyResponse.PublicKey) {
+      return null;
+    }
+
+    // 캐시 업데이트
+    this.cachedPublicKey = new Uint8Array(publicKeyResponse.PublicKey);
+    this.publicKeyCacheTime = now;
+
+    return this.cachedPublicKey;
+  }
+
+  /**
+   * 캐시 초기화
+   */
+  clearCache(): void {
+    this.cachedPublicKey = null;
+    this.publicKeyCacheTime = 0;
+  }
+}
+
+/**
+ * JWE 서비스 인스턴스 생성 헬퍼
+ * @returns JWE 서비스 인스턴스
+ */
+export function createJWEService(authMode: 'guest' | 'iam' = 'guest'): JWEService {
+  const config: JWEServiceConfig = {
+    identityPoolId: import.meta.env.VITE_COGNITO_IDENTITY_POOL_ID,
+    region: import.meta.env.VITE_AWS_REGION,
+    kmsKeyId: import.meta.env.VITE_KMS_KEY_ID,
+    authMode
+  };
+
+  if (authMode === 'iam') {
+    config.iamCredentials = {
+      accessKeyId: import.meta.env.VITE_AWS_ACCESS_KEY_ID,
+      secretAccessKey: import.meta.env.VITE_AWS_SECRET_ACCESS_KEY,
+      frontendRoleArn: import.meta.env.VITE_FRONTEND_ROLE_ARN
+    };
+  }
+
+  return new JWEService(config);
+}

--- a/src/services/jwe/jweTokenGenerator.ts
+++ b/src/services/jwe/jweTokenGenerator.ts
@@ -1,0 +1,110 @@
+/**
+ * JWE 토큰 생성 유틸리티
+ * KMS 공개키를 사용하여 JWE 토큰을 생성합니다.
+ */
+
+import { importSPKI, CompactEncrypt } from 'jose';
+
+export interface JWEPayload {
+  userId: string;
+  sessionId: string;
+  timestamp: number;
+  [key: string]: any;
+}
+
+export interface JWEGenerationResult {
+  success: boolean;
+  token?: string;
+  error?: string;
+  details?: any;
+}
+
+/**
+ * PEM 형식의 공개키로 변환
+ * @param publicKeyBytes 공개키 바이트 배열
+ * @returns PEM 형식의 공개키 문자열
+ */
+export function convertToPEM(publicKeyBytes: Uint8Array): string {
+  // Base64 인코딩
+  const base64 = btoa(String.fromCharCode(...publicKeyBytes));
+  
+  // PEM 형식으로 포맷팅
+  const pem = `-----BEGIN PUBLIC KEY-----\n${base64.match(/.{1,64}/g)?.join('\n')}\n-----END PUBLIC KEY-----`;
+  
+  return pem;
+}
+
+/**
+ * KMS 공개키를 사용하여 JWE 토큰 생성
+ * @param publicKeyBytes KMS에서 가져온 공개키 바이트 배열
+ * @param payload 암호화할 페이로드
+ * @returns JWE 토큰 생성 결과
+ */
+export async function generateJWEToken(
+  publicKeyBytes: Uint8Array,
+  payload: JWEPayload
+): Promise<JWEGenerationResult> {
+  try {
+    // 1. 공개키를 PEM 형식으로 변환
+    const pemKey = convertToPEM(publicKeyBytes);
+    console.log('PEM 형식 공개키 생성 완료');
+
+    // 2. JOSE 라이브러리에서 사용할 수 있는 키 형식으로 임포트
+    const publicKey = await importSPKI(pemKey, 'RSA-OAEP-256');
+    console.log('공개키 임포트 완료');
+
+    // 3. 페이로드를 JSON 문자열로 변환
+    const payloadString = JSON.stringify(payload);
+    const encoder = new TextEncoder();
+    const payloadBytes = encoder.encode(payloadString);
+
+    // 4. JWE 토큰 생성
+    const jwe = await new CompactEncrypt(payloadBytes)
+      .setProtectedHeader({ 
+        alg: 'RSA-OAEP-256',  // KMS에서 지원하는 알고리즘
+        enc: 'A256GCM'        // 대칭키 암호화 알고리즘
+      })
+      .encrypt(publicKey);
+
+    console.log('JWE 토큰 생성 완료');
+
+    return {
+      success: true,
+      token: jwe,
+      details: {
+        algorithm: 'RSA-OAEP-256',
+        encryption: 'A256GCM',
+        payloadSize: payloadBytes.length,
+        tokenLength: jwe.length
+      }
+    };
+
+  } catch (error) {
+    console.error('JWE 토큰 생성 실패:', error);
+    
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : '알 수 없는 오류',
+      details: error
+    };
+  }
+}
+
+/**
+ * 테스트용 페이로드 생성
+ * @param userId 사용자 ID
+ * @returns JWE 페이로드
+ */
+export function createTestPayload(userId: string = 'test-user'): JWEPayload {
+  return {
+    userId,
+    sessionId: `session-${Date.now()}`,
+    timestamp: Date.now(),
+    cognitoIdentityId: 'ap-northeast-1:xxxx-xxxx-xxxx',
+    customData: {
+      browser: navigator.userAgent,
+      language: navigator.language,
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone
+    }
+  };
+}

--- a/src/types/jwe.ts
+++ b/src/types/jwe.ts
@@ -1,0 +1,46 @@
+/**
+ * JWE 관련 타입 정의
+ */
+
+import { JWEPayload } from '../services/jwe/jweTokenGenerator';
+
+/**
+ * 채팅 API용 JWE 페이로드
+ */
+export interface ChatJWEPayload extends JWEPayload {
+  /** 클라이언트 ID */
+  client_id: string;
+  /** 애플리케이션 ID */
+  app_id: string;
+  /** 요청 타입 (채팅용) */
+  request_type: 'chat';
+}
+
+/**
+ * JWE 토큰 생성 옵션
+ */
+export interface JWETokenOptions {
+  /** 인증 모드 */
+  authMode?: 'iam';
+  /** 토큰 유효시간 (초) */
+  expiresIn?: number;
+}
+
+/**
+ * JWE 헤더 생성 결과
+ */
+export interface JWEHeaderResult {
+  /** 성공 여부 */
+  success: boolean;
+  /** JWE 토큰 (성공 시) */
+  token?: string;
+  /** 에러 메시지 (실패 시) */
+  error?: string;
+  /** 상세 정보 */
+  details?: {
+    client_id: string;
+    app_id: string;
+    tokenLength?: number;
+    authMode: string;
+  };
+}


### PR DESCRIPTION
## Summary
- ✅ JWE 토큰 생성 기능 구현 (KMS 공개키 + jose 라이브러리)
- ✅ 채팅 API용 JWE 서비스 생성 (client_id, app_id 암호화)
- ✅ 채팅 API 요청에 JWE 헤더 통합 (X-JWE-Token)
- ✅ JWE 기능 종합 테스트 인터페이스 추가
- ✅ AWS 서비스용 IAM 기반 인증 구현
- ✅ 모든 컴포넌트에서 게스트 모드 인증 제거
- ✅ API Gateway CORS 설정 (X-JWE-Token 헤더 허용)
- ✅ 개발 도구를 전용 dev/ 폴더 구조로 정리
- ✅ 환경별 조건부 렌더링 추가
- ✅ 보안을 위해 .env 파일을 Git 추적에서 제거

## Test plan
- [x] JWE 토큰 생성 테스트
- [x] 채팅 API JWE 헤더 통합 테스트  
- [x] API Gateway CORS 설정 확인
- [x] IAM 인증 모드 테스트
- [x] 프로덕션 빌드 테스트
- [x] dev 페이지 접근 제한 확인

🤖 Generated with [Claude Code](https://claude.ai/code)