### PR TITLE
[UI] PC 환경에서 하단 메뉴 너비 500px 고정 (#44)

### DIFF
--- a/src/components/organisms/MenuModal/MenuModal.test.tsx
+++ b/src/components/organisms/MenuModal/MenuModal.test.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MenuModal } from './MenuModal';
+import { LocaleProvider } from '../../../contexts/LocaleContext';
+
+// Mock 메뉴 설정
+const mockMenuConfig = {
+  items: [
+    {
+      id: 'item1',
+      icon: { type: 'lucide' as const, value: 'Home' },
+      label: '홈',
+      action: 'navigate' as const
+    },
+    {
+      id: 'item2', 
+      icon: { type: 'lucide' as const, value: 'User' },
+      label: '프로필',
+      action: 'navigate' as const
+    },
+    {
+      id: 'item3',
+      icon: { type: 'lucide' as const, value: 'Settings' },
+      label: '설정',
+      action: 'navigate' as const
+    }
+  ],
+  cta: {
+    label: '문의하기',
+    action: 'external-link' as const,
+    url: 'https://example.com'
+  }
+};
+
+const renderMenuModal = (props = {}) => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: jest.fn(),
+    menuConfig: mockMenuConfig,
+    accentColor: 'orange' as const,
+    onMenuItemClick: jest.fn()
+  };
+
+  return render(
+    <LocaleProvider>
+      <MenuModal {...defaultProps} {...props} />
+    </LocaleProvider>
+  );
+};
+
+describe('MenuModal PC 환경 너비 테스트', () => {
+  beforeEach(() => {
+    // PC 환경 시뮬레이션 (768px 이상)
+    Object.defineProperty(window, 'innerWidth', {
+      writable: true,
+      configurable: true,
+      value: 1024,
+    });
+    
+    // matchMedia mock
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation(query => ({
+        matches: query.includes('min-width: 768px'),
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
+  });
+
+  test('PC 환경에서 모달 너비가 500px로 설정되어야 함', () => {
+    renderMenuModal();
+    
+    const modal = screen.getByRole('button', { name: /close/i }).closest('div[data-testid="menu-modal"]') || 
+                 document.querySelector('[class*="transform"][class*="shadow-xl"]');
+    
+    expect(modal).toBeInTheDocument();
+    
+    // PC 환경에서 500px 너비 클래스 확인
+    expect(modal).toHaveClass('sm:w-[500px]');
+    expect(modal).toHaveClass('sm:max-w-[500px]');
+  });
+
+  test('PC 환경에서 좌우 여백이 제거되어야 함', () => {
+    renderMenuModal();
+    
+    const modal = document.querySelector('[class*="transform"][class*="shadow-xl"]');
+    
+    // mx-auto 클래스로 중앙 정렬되어야 함
+    expect(modal).toHaveClass('mx-auto');
+    
+    // 내부 콘텐츠 컨테이너에 패딩 확인
+    const menuContainer = screen.getByRole('button', { name: /홈/i }).closest('.px-4');
+    expect(menuContainer).toBeInTheDocument();
+  });
+
+  test('모바일 환경에서는 전체 너비 유지', () => {
+    // 모바일 환경 시뮬레이션
+    Object.defineProperty(window, 'innerWidth', {
+      value: 375,
+    });
+    
+    Object.defineProperty(window, 'matchMedia', {
+      value: jest.fn().mockImplementation(query => ({
+        matches: !query.includes('min-width: 768px'),
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
+
+    renderMenuModal();
+    
+    const modal = document.querySelector('[class*="transform"][class*="shadow-xl"]');
+    
+    // 모바일에서는 w-full 클래스 적용
+    expect(modal).toHaveClass('w-full');
+  });
+
+  test('메뉴 아이템들이 올바르게 렌더링되어야 함', () => {
+    renderMenuModal();
+    
+    // 모든 메뉴 아이템이 렌더링되는지 확인
+    expect(screen.getByText('홈')).toBeInTheDocument();
+    expect(screen.getByText('프로필')).toBeInTheDocument();
+    expect(screen.getByText('설정')).toBeInTheDocument();
+    
+    // CTA 버튼이 렌더링되는지 확인
+    expect(screen.getByText('문의하기')).toBeInTheDocument();
+  });
+
+  test('PC 환경에서 모달이 중앙에 정렬되어야 함', () => {
+    renderMenuModal();
+    
+    const modalContainer = document.querySelector('.fixed.inset-0');
+    
+    // 모달 컨테이너가 중앙 정렬 클래스를 가져야 함
+    expect(modalContainer).toHaveClass('justify-center');
+    expect(modalContainer).toHaveClass('items-end');
+  });
+});

--- a/src/components/organisms/MenuModal/MenuModal.tsx
+++ b/src/components/organisms/MenuModal/MenuModal.tsx
@@ -83,12 +83,13 @@ export function MenuModal({
     >
       <div
         ref={modalRef}
+        data-testid="menu-modal"
         className={`
           ${colors.bgLight} shadow-xl
           transform transition-transform duration-300 ease-out
           ${isOpen ? 'translate-y-0' : 'translate-y-full'}
-          w-full max-w-lg mx-auto
-          sm:max-w-md sm:mb-4
+          w-full mx-auto
+          sm:w-[500px] sm:max-w-[500px] sm:mb-4
         `}
         style={{ paddingBottom: 'max(1rem, env(safe-area-inset-bottom))' }}
         onClick={(e) => e.stopPropagation()}


### PR DESCRIPTION
## 📝 구현 내용
PC 환경에서 채팅 위젯의 하단 메뉴 너비를 500px로 고정하여 UI 정렬을 개선했습니다.

### 변경사항
- MenuModal 컴포넌트의 반응형 클래스 수정
- PC 환경: `sm:w-[500px] sm:max-w-[500px]`로 고정 너비 설정
- 모바일 환경: 기존 `w-full` 동작 유지
- 테스트 코드 추가로 반응형 동작 검증

## 💡 고려한 개념
### Tailwind CSS 반응형 설계
- `sm:` 접두사 활용으로 768px 이상에서만 고정 너비 적용
- 모바일 우선(mobile-first) 접근 방식 유지
- `mx-auto`로 중앙 정렬 보장

### 사용자 경험(UX) 일관성
- 모달과 하단 메뉴의 너비 일치로 시각적 정렬감 확보
- 다양한 화면 크기에서 최적화된 레이아웃 제공

## 🧠 습득한 배경지식
### CSS Grid와 반응형 레이아웃
- 메뉴 아이템 개수에 따른 동적 그리드 시스템 이해
- 3개, 4개, 6개 아이템에 따른 레이아웃 분기 처리

### 테스트 주도 개발(TDD)
- 반응형 동작을 검증하는 테스트 작성 방법
- `matchMedia` API 모킹으로 브라우저 환경 시뮬레이션
- `data-testid` 활용한 컴포넌트 테스트 전략

## ⚠️ 향후 주의사항
### 채팅 위젯과의 동기화
- ai-navi-chatbot-widget의 모달 너비 변경 시 함께 조정 필요
- 두 프로젝트 간 UI 일관성 유지 중요

### 브레이크포인트 관리
- 현재 768px 기준점 사용 중
- 태블릿 등 중간 크기 디바이스 고려 시 추가 브레이크포인트 검토 필요

### 테스트 환경
- LocaleProvider의 비동기 로직으로 인한 act() 경고 발생
- 향후 테스트 유틸리티 개선으로 경고 해결 고려

## ✅ 테스트
- [x] PC 환경에서 500px 고정 너비 확인
- [x] 모바일 환경에서 전체 너비 유지 확인
- [x] 중앙 정렬 및 여백 제거 확인
- [x] 메뉴 아이템 정상 렌더링 확인

Fixes #44