### PR TITLE
fix: useChat 훅 LLMResponse 타입 오류 수정

### DIFF
--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -186,7 +186,10 @@ export function useChat({ userId, gradeId, onError, onTypingComplete }: UseChatO
       message: message,
       toolName: undefined,
       toolInput: undefined,
-      llmResponse: llmResponse ? { content: message } : undefined,
+      llmResponse: llmResponse ? { 
+        response: [{ type: 'main', text: message }],
+        status: 200 
+      } : undefined,
       messageId: messageId // 메시지 ID를 포함하여 completeTyping에서 사용
     });
     


### PR DESCRIPTION
## 문제점
`addTypingBotMessage` 함수에서 잘못된 LLMResponse 구조 사용으로 인한 TypeScript 컴파일 오류 발생

### 오류 상세
```typescript
// 기존 코드 (오류)
llmResponse: llmResponse ? { content: message } : undefined,

// TypeScript 오류: 'content' 속성이 LLMResponse 타입에 존재하지 않음
```

## 해결 방법
LLMResponse 인터페이스 구조에 맞게 올바른 형태로 수정

### 수정된 코드
```typescript
llmResponse: llmResponse ? { 
  response: [{ type: 'main', text: message }],
  status: 200 
} : undefined,
```

## 변경 사항
- **타입 안전성 확보**: LLMResponse 인터페이스 구조에 정확히 맞는 객체 생성
- **BubbleResponse 구조 준수**: `{ type: 'main', text: message }` 형태의 올바른 버블 응답 생성
- **완전한 LLMResponse 구현**: `response` 배열과 `status` 속성 포함

## 관련 맥락
이 오류는 FAQ 중복 표시 버그 수정 과정(#48)에서 메시지 ID 기반 컴포넌트 제어 시스템을 구현하면서 발견되었습니다.

## 테스트
- ✅ TypeScript 컴파일 오류 해결 확인
- ✅ 기존 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.ai/code)