### PR TITLE
Fix iOS scroll issue for GradeQuickReply component (Issue #58)

### DIFF
--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -172,9 +172,29 @@ function MainPage() {
       // 학년별 퀵 리플라이 표시
       setTimeout(() => {
         setShowFigmaQuickReply(true);
-        setTimeout(() => {
-          messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-        }, 100);
+        
+        // iOS에서 GradeQuickReply 표시 후 지연된 강제 스크롤
+        if (isIOS()) {
+          // 첫 번째 스크롤 시도 (50ms 후)
+          setTimeout(() => {
+            if (chatContainerRef.current) {
+              const container = chatContainerRef.current;
+              container.scrollTop = container.scrollHeight;
+            }
+          }, 50);
+          
+          // 두 번째 확실한 스크롤 (100ms 후)
+          setTimeout(() => {
+            if (chatContainerRef.current) {
+              const container = chatContainerRef.current;
+              container.scrollTop = container.scrollHeight;
+            }
+          }, 100);
+        } else {
+          setTimeout(() => {
+            messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+          }, 100);
+        }
       }, 1000);
     }, 500);
   };


### PR DESCRIPTION
## 🎯 목적

iOS에서 학년 선택 후 GradeQuickReply 컴포넌트가 표시될 때, 하단 컨텐츠(특히 "その他" 버튼)가 화면에서 잘려 보이지 않는 문제를 해결합니다.

## 📱 이슈 상황

- **문제**: iOS 디바이스에서 학년 선택 완료 후 GradeQuickReply가 처음 표시될 때 최하단 버튼이 잘림
- **원인**: iOS의 스크롤 동작과 컨텐츠 렌더링 타이밍 불일치
- **영향**: 사용자가 "その他" 버튼을 클릭할 수 없어 UX 저하

## 🔧 구현 방법

### 지연된 강제 스크롤 구현
```typescript
// iOS에서만 적용되는 2단계 스크롤
if (isIOS()) {
  // 첫 번째 스크롤 시도 (50ms 후)
  setTimeout(() => {
    if (chatContainerRef.current) {
      const container = chatContainerRef.current;
      container.scrollTop = container.scrollHeight;
    }
  }, 50);
  
  // 두 번째 확실한 스크롤 (100ms 후)
  setTimeout(() => {
    if (chatContainerRef.current) {
      const container = chatContainerRef.current;
      container.scrollTop = container.scrollHeight;
    }
  }, 100);
}
```

### 핵심 개념
- **2단계 스크롤**: 50ms, 100ms 지연으로 확실한 최하단 스크롤 보장
- **플랫폼 분기**: iOS에서만 적용하여 다른 브라우저 동작에 영향 없음
- **직접 scrollTop 조작**: `chatContainerRef`를 이용한 성능 최적화
- **기존 동작 유지**: 다른 브라우저에서는 smooth scroll 유지

## 📋 적용한 변경사항

### MainPage.tsx:160-200
- `handleGradeSelect` 함수 내 iOS 조건부 스크롤 로직 추가
- `isIOS()` 유틸리티 함수를 이용한 플랫폼 감지
- 기존 `messagesEndRef.scrollIntoView` 동작은 다른 브라우저에서 유지

## 🧪 테스트 방법

1. **iOS 테스트** (Safari/Chrome)
   - 학년 선택 완료
   - GradeQuickReply 표시 후 모든 버튼이 완전히 보이는지 확인
   - "その他" 버튼 클릭 가능 여부 확인

2. **다른 브라우저 테스트**
   - 기존 smooth scroll 동작 유지 확인
   - 성능 저하 없음 확인

## 🔍 경험한 시행착오

- **초기 접근**: 단일 지연 스크롤로 시도했으나 iOS의 렌더링 타이밍과 맞지 않음
- **해결**: 2단계 지연 스크롤로 확실한 최하단 이동 보장
- **성능 고려**: `requestAnimationFrame` 대신 간단한 `setTimeout` 사용으로 충분함

## 🎓 습득한 도메인 지식

- **iOS 스크롤 특성**: iOS는 컨텐츠 렌더링과 스크롤 동작의 타이밍이 다른 브라우저와 상이
- **React 라이프사이클**: 컴포넌트 상태 변경 후 DOM 업데이트까지의 지연 시간 고려 필요
- **모바일 최적화**: 플랫폼별 분기 처리를 통한 최적화 방법

## ⚠️ 향후 주의사항

- iOS 버전 업데이트 시 스크롤 동작 변경 가능성 모니터링 필요
- 다른 컴포넌트에서 유사한 스크롤 이슈 발생 시 동일한 패턴 적용 가능
- 성능 영향 최소화를 위해 iOS에서만 동작하도록 조건 처리 유지

## 🔗 관련 이슈

Closes #58

🤖 Generated with [Claude Code](https://claude.ai/code)