### PR TITLE
fix: iOS에서 textarea 폰트가 다르게 표시되는 문제 해결

### DIFF
--- a/src/components/molecules/InputField/InputField.test.tsx
+++ b/src/components/molecules/InputField/InputField.test.tsx
@@ -8,6 +8,7 @@
  * - PC 환경(500px 이상)에서 너비 387px 동적 스타일 적용
  * - 모바일 환경(500px 미만)에서 기존 반응형 디자인 유지
  * - 입력창 기본 기능 정상 작동
+ * - iOS 환경에서 폰트 렌더링 문제 해결 (이슈 #68)
  */
 
 import React from 'react';
@@ -187,13 +188,26 @@ describe('InputField', () => {
       const textarea = screen.getByRole('textbox');
       expect(textarea).toHaveStyle({
         maxHeight: '270px',
-        fontFamily: 'Work Sans',
+        fontFamily: '"Noto Sans", "Work Sans", sans-serif',
         fontSize: '16px',
         fontWeight: 400,
         lineHeight: '24px',
         width: '100%',
         minHeight: '24px'
       });
+    });
+
+    it('iOS 환경에서 textarea에 추가 스타일이 적용된다', () => {
+      render(<InputField {...defaultProps} />);
+      
+      const textarea = screen.getByRole('textbox');
+      // iOS에서 폰트 렌더링 문제 해결을 위한 스타일
+      const style = window.getComputedStyle(textarea);
+      
+      // React inline styles는 camelCase이지만, 실제 DOM에서는 kebab-case로 변환됨
+      expect(textarea.style.WebkitAppearance).toBe('none');
+      expect(textarea.style.WebkitFontSmoothing).toBe('antialiased');  
+      expect(textarea.style.MozOsxFontSmoothing).toBe('grayscale');
     });
   });
 

--- a/src/components/molecules/InputField/InputField.tsx
+++ b/src/components/molecules/InputField/InputField.tsx
@@ -88,13 +88,16 @@ export function InputField({
         style={{
           maxHeight: '270px',
           alignSelf: 'stretch',
-          fontFamily: 'Work Sans',
+          fontFamily: '"Noto Sans", "Work Sans", sans-serif',
           fontSize: '16px',
           fontStyle: 'normal',
           fontWeight: 400,
           lineHeight: '24px',
           width: '100%',
           minHeight: '24px',
+          WebkitAppearance: 'none',
+          WebkitFontSmoothing: 'antialiased',
+          MozOsxFontSmoothing: 'grayscale',
         }}
         rows={1}
         disabled={disabled}


### PR DESCRIPTION
## 📋 개요
iOS 환경에서 입력창(textarea)의 폰트가 다른 UI 요소와 달리 표시되는 문제를 해결했습니다. Noto Sans 폰트로 통일하고 iOS 특화 스타일을 적용했습니다.

## 🔧 구현 방법
### TDD(Test-Driven Development) 방식 채택
1. 테스트 케이스 먼저 작성
2. 테스트 실패 확인
3. 최소한의 코드로 테스트 통과
4. 리팩토링 (필요시)

### 구체적 수정사항
```typescript
// 변경 전
fontFamily: 'Work Sans'

// 변경 후  
fontFamily: '"Noto Sans", "Work Sans", sans-serif'
```

### iOS 렌더링 개선 속성 추가
```typescript
WebkitAppearance: 'none',          // iOS 기본 스타일 제거
WebkitFontSmoothing: 'antialiased', // 웹킷 폰트 스무딩
MozOsxFontSmoothing: 'grayscale'    // Firefox 폰트 스무딩
```

## 💡 적용한 개념
1. **웹 폰트 우선순위**: fallback 폰트 체인으로 안정성 확보
2. **크로스 브라우저 호환성**: vendor prefix 활용
3. **TDD 실천**: Red-Green-Refactor 사이클
4. **플랫폼 특화 스타일링**: iOS 렌더링 이슈 해결

## 🚧 경험한 시행착오
### 1. 테스트 스타일 검증 방식
- **문제**: `toHaveStyle()` 매처가 camelCase 속성명 인식 실패
- **해결**: `textarea.style` 직접 접근으로 검증
```javascript
// 실패한 방식
expect(textarea).toHaveStyle({ WebkitAppearance: 'none' });

// 성공한 방식  
expect(textarea.style.WebkitAppearance).toBe('none');
```

### 2. 폰트 선언 문자열 처리
- **문제**: 폰트명에 공백 포함 시 따옴표 처리 필요
- **해결**: 이중 따옴표로 폰트명 감싸기
```javascript
fontFamily: '"Noto Sans", "Work Sans", sans-serif'
```

## 📚 습득한 도메인지식
1. **iOS Safari 특이사항**
   - form 요소에 대해 자체 스타일링 적용
   - `-webkit-appearance: none`으로 초기화 필요

2. **폰트 렌더링 최적화**
   - `font-smoothing` 속성으로 가독성 개선
   - 플랫폼별로 다른 렌더링 엔진 고려 필요

3. **React 인라인 스타일**
   - CSS 속성명을 camelCase로 변환
   - vendor prefix도 camelCase 적용 (예: WebkitAppearance)

## ⚠️ 향후 주의사항
1. **폰트 로딩 확인**
   - Noto Sans 웹폰트가 실제로 로드되는지 검증 필요
   - 폰트 로딩 실패 시 fallback 동작 확인

2. **성능 고려사항**
   - 폰트 스무딩 속성이 렌더링 성능에 미치는 영향 모니터링
   - 저사양 디바이스에서 테스트 필요

3. **접근성 확인**
   - 폰트 변경이 가독성에 미치는 영향 평가
   - 다양한 화면 크기와 해상도에서 테스트

4. **일관성 유지**
   - 다른 입력 요소들도 동일한 스타일 적용 검토
   - 디자인 시스템 전체적으로 폰트 정책 통일

## 🧪 테스트 결과
- 기존 테스트 모두 통과 (14개)
- 신규 iOS 스타일 테스트 추가 (1개)
- 총 15개 테스트 케이스 통과

관련 이슈: #68

🤖 Generated with [Claude Code](https://claude.ai/code)