### PR TITLE
deploy meimonkai demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>錬成会CS AI Navi</title>
+    <title>CS AI Navi</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,25 +1,28 @@
 import { StrictMode } from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { LocaleProvider } from './contexts/LocaleContext';
+import { ClientConfigProvider } from './contexts/ClientConfigContext';
 import MainPage from './pages/MainPage';
 import { CognitoTestPage, JWETestPage } from './dev';
 
 function App() {
   return (
     <BrowserRouter>
-      <LocaleProvider>
-      <Routes>
-          <Route path="/" element={<MainPage />} />
-          {/* 개발/테스트용 라우트 */}
-          {!import.meta.env.PROD && (
-            <>
-              <Route path="/dev/jwe-test" element={<JWETestPage />} />
-              <Route path="/dev/cognito-test" element={<CognitoTestPage />} />
-            </>
-          )}
-          <Route path="*" element={<Navigate to="/" replace />} />
-        </Routes>
-      </LocaleProvider>
+      <ClientConfigProvider>
+        <LocaleProvider>
+          <Routes>
+            <Route path="/" element={<MainPage />} />
+            {/* 개발/테스트용 라우트 */}
+            {!import.meta.env.PROD && (
+              <>
+                <Route path="/dev/jwe-test" element={<JWETestPage />} />
+                <Route path="/dev/cognito-test" element={<CognitoTestPage />} />
+              </>
+            )}
+            <Route path="*" element={<Navigate to="/" replace />} />
+          </Routes>
+        </LocaleProvider>
+      </ClientConfigProvider>
     </BrowserRouter>
   );
 }

--- a/src/components/organisms/GradeSelection/GradeSelection.tsx
+++ b/src/components/organisms/GradeSelection/GradeSelection.tsx
@@ -8,17 +8,24 @@ interface GradeSelectionProps {
   onGradeSelect: (grade: GradeType) => void;
   accentColor?: AccentColor;
   className?: string;
+  clientId?: string;
 }
 
 export const GradeSelection: React.FC<GradeSelectionProps> = ({
   onGradeSelect,
   accentColor: propAccentColor,
-  className = ''
+  className = '',
+  clientId
 }) => {
   const { t } = useLocale();
   const defaultAccentColor = getAccentColor();
   const accentColor = propAccentColor || defaultAccentColor;
   const colors = getColorClasses(accentColor);
+  
+  // MM000002일 때는 유아(preschool)를 제외
+  const filteredGrades = clientId === 'MM000002' 
+    ? GRADE_OPTIONS.filter(grade => grade.type !== 'preschool')
+    : GRADE_OPTIONS;
 
   return (
     <div
@@ -40,7 +47,7 @@ export const GradeSelection: React.FC<GradeSelectionProps> = ({
       </div>
 
       {/* Grade Options */}
-      {GRADE_OPTIONS.map((grade) => (
+      {filteredGrades.map((grade) => (
         <div key={grade.type} className="relative shrink-0 w-full">
           <div className="flex flex-row items-center overflow-clip relative size-full">
             <div className="box-border content-stretch flex flex-row gap-2.5 items-center justify-start pl-5 pr-0 py-0 relative w-full">

--- a/src/components/organisms/NavigationHeader/NavigationHeader.tsx
+++ b/src/components/organisms/NavigationHeader/NavigationHeader.tsx
@@ -12,6 +12,8 @@ interface NavigationHeaderProps {
   title: string;
   accentColor?: AccentColor;
   clientId?: string;
+  clientName?: string;
+  schoolName?: string;
   showLogo?: boolean;
   showDynamicHeader?: boolean;
   onHeaderAction?: (action: HeaderAction) => void;
@@ -20,6 +22,8 @@ interface NavigationHeaderProps {
 export default function NavigationHeader({ 
   accentColor: propAccentColor, 
   clientId = 'default',
+  clientName,
+  schoolName,
   showLogo = true,
   showDynamicHeader = false,
   onHeaderAction
@@ -76,12 +80,18 @@ export default function NavigationHeader({
                 <ArrowLeft className="w-6 h-6" />
               </button>
             )}
-            {showLogo && (
+            {showLogo && schoolName && (
               <div className="flex items-center gap-2">
                 <div className="flex items-center">
                   <span className={`text-2xl font-bold ${colors.accent}`}>∞</span>
-                  <span className={`text-xl font-bold ${colors.textSecondary} ml-1`}>3.14</span>
-                  <span className={`text-lg font-medium ${colors.accentSecondary} ml-1`}>community</span>
+                  {schoolName === '3.14 community' ? (
+                    <>
+                      <span className={`text-xl font-bold ${colors.textSecondary} ml-1`}>3.14</span>
+                      <span className={`text-lg font-medium ${colors.accentSecondary} ml-1`}>community</span>
+                    </>
+                  ) : (
+                    <span className={`text-xl font-bold ${colors.textSecondary} ml-1`}>{schoolName}</span>
+                  )}
                 </div>
               </div>
             )}

--- a/src/config/clientMappings.ts
+++ b/src/config/clientMappings.ts
@@ -1,0 +1,63 @@
+/**
+ * 클라이언트 ID별 설정 매핑
+ * client_id에 따라 client_name과 school_name을 동적으로 설정
+ */
+
+export interface ClientMapping {
+  clientId: string;
+  clientName: string;
+  schoolName: string;
+}
+
+// 클라이언트별 매핑 정의
+export const CLIENT_MAPPINGS: Record<string, ClientMapping> = {
+  // 錬成会
+  'RS000001': {
+    clientId: 'RS000001',
+    clientName: '錬成会',
+    schoolName: '3.14 community'
+  },
+  
+  // 名門会
+  'MM000002': {
+    clientId: 'MM000002', 
+    clientName: '名門会',
+    schoolName: '名門会'
+  },
+  
+  // 기본값 (매핑이 없는 경우)
+  'default': {
+    clientId: 'RS000001',
+    clientName: '錬成会',
+    schoolName: '3.14 community'
+  }
+};
+
+/**
+ * 클라이언트 ID로 매핑 정보 가져오기
+ * @param clientId 클라이언트 ID
+ * @returns 클라이언트 매핑 정보
+ */
+export function getClientMapping(clientId: string): ClientMapping {
+  return CLIENT_MAPPINGS[clientId] || CLIENT_MAPPINGS['default'];
+}
+
+/**
+ * 클라이언트 이름 가져오기
+ * @param clientId 클라이언트 ID
+ * @returns 클라이언트 이름
+ */
+export function getClientName(clientId: string): string {
+  const mapping = getClientMapping(clientId);
+  return mapping.clientName;
+}
+
+/**
+ * 학교 이름 가져오기
+ * @param clientId 클라이언트 ID
+ * @returns 학교 이름
+ */
+export function getSchoolName(clientId: string): string {
+  const mapping = getClientMapping(clientId);
+  return mapping.schoolName;
+}

--- a/src/contexts/ClientConfigContext.tsx
+++ b/src/contexts/ClientConfigContext.tsx
@@ -1,0 +1,150 @@
+import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { useLocation } from 'react-router-dom';
+import { getClientMapping } from '../config/clientMappings';
+
+interface ClientConfig {
+  clientId: string;
+  appId: string;
+  clientName: string;
+  schoolName: string;
+}
+
+interface ClientConfigContextType {
+  config: ClientConfig;
+  updateConfig: (newConfig: Partial<ClientConfig>) => void;
+  clearConfig: () => void;
+}
+
+// 하드코딩된 기본값
+const DEFAULT_CLIENT_ID = 'RS000001';
+const DEFAULT_APP_ID = '0001';
+
+const ClientConfigContext = createContext<ClientConfigContextType | undefined>(undefined);
+
+export function ClientConfigProvider({ children }: { children: ReactNode }) {
+  const location = useLocation();
+  const defaultMapping = getClientMapping(DEFAULT_CLIENT_ID);
+  const [config, setConfig] = useState<ClientConfig>({
+    clientId: DEFAULT_CLIENT_ID,
+    appId: DEFAULT_APP_ID,
+    clientName: defaultMapping.clientName,
+    schoolName: defaultMapping.schoolName
+  });
+
+  // 초기 로드 시 쿼리 파라미터 및 sessionStorage 확인
+  useEffect(() => {
+    const searchParams = new URLSearchParams(location.search);
+    const queryClientId = searchParams.get('clientId');
+    const queryAppId = searchParams.get('appId');
+
+    // 우선순위: 쿼리 파라미터 > sessionStorage > 기본값
+    const finalClientId = 
+      queryClientId || 
+      sessionStorage.getItem('clientId') || 
+      DEFAULT_CLIENT_ID;
+    
+    const finalAppId = 
+      queryAppId || 
+      sessionStorage.getItem('appId') || 
+      DEFAULT_APP_ID;
+
+    // 쿼리 파라미터가 있으면 sessionStorage에 저장
+    if (queryClientId) {
+      sessionStorage.setItem('clientId', queryClientId);
+      console.log(`ClientId saved to sessionStorage: ${queryClientId}`);
+    }
+    if (queryAppId) {
+      sessionStorage.setItem('appId', queryAppId);
+      console.log(`AppId saved to sessionStorage: ${queryAppId}`);
+    }
+
+    // clientId에 따른 매핑 정보 가져오기
+    const mapping = getClientMapping(finalClientId);
+
+    // 설정 업데이트
+    setConfig({
+      clientId: finalClientId,
+      appId: finalAppId,
+      clientName: mapping.clientName,
+      schoolName: mapping.schoolName
+    });
+
+    console.log('ClientConfig initialized:', {
+      clientId: finalClientId,
+      appId: finalAppId,
+      clientName: mapping.clientName,
+      schoolName: mapping.schoolName,
+      source: queryClientId || queryAppId 
+        ? 'query params' 
+        : sessionStorage.getItem('clientId') || sessionStorage.getItem('appId')
+          ? 'sessionStorage'
+          : 'default values'
+    });
+  }, [location.search]);
+
+  // 설정 업데이트 함수
+  const updateConfig = (newConfig: Partial<ClientConfig>) => {
+    setConfig(prev => {
+      let updated = { ...prev, ...newConfig };
+      
+      // clientId가 변경되면 매핑 정보도 업데이트
+      if (newConfig.clientId && newConfig.clientId !== prev.clientId) {
+        const mapping = getClientMapping(newConfig.clientId);
+        updated = {
+          ...updated,
+          clientName: mapping.clientName,
+          schoolName: mapping.schoolName
+        };
+      }
+      
+      // sessionStorage에도 저장
+      if (newConfig.clientId) {
+        sessionStorage.setItem('clientId', newConfig.clientId);
+      }
+      if (newConfig.appId) {
+        sessionStorage.setItem('appId', newConfig.appId);
+      }
+      
+      console.log('ClientConfig updated:', updated);
+      return updated;
+    });
+  };
+
+  // 설정 초기화 함수
+  const clearConfig = () => {
+    sessionStorage.removeItem('clientId');
+    sessionStorage.removeItem('appId');
+    const defaultMapping = getClientMapping(DEFAULT_CLIENT_ID);
+    setConfig({
+      clientId: DEFAULT_CLIENT_ID,
+      appId: DEFAULT_APP_ID,
+      clientName: defaultMapping.clientName,
+      schoolName: defaultMapping.schoolName
+    });
+    console.log('ClientConfig cleared and reset to defaults');
+  };
+
+  return (
+    <ClientConfigContext.Provider value={{ config, updateConfig, clearConfig }}>
+      {children}
+    </ClientConfigContext.Provider>
+  );
+}
+
+// Context를 사용하는 커스텀 훅
+export function useClientConfig() {
+  const context = useContext(ClientConfigContext);
+  if (context === undefined) {
+    throw new Error('useClientConfig must be used within a ClientConfigProvider');
+  }
+  return context.config;
+}
+
+// 전체 Context를 반환하는 훅 (설정 업데이트가 필요한 경우)
+export function useClientConfigContext() {
+  const context = useContext(ClientConfigContext);
+  if (context === undefined) {
+    throw new Error('useClientConfigContext must be used within a ClientConfigProvider');
+  }
+  return context;
+}

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -9,6 +9,8 @@ import type { Message, LLMResponse } from '../types';
 interface UseChatOptions {
   userId: string;
   gradeId?: string;
+  clientId?: string;
+  appId?: string;
   onError?: (error: Error) => void;
   onTypingComplete?: () => void;
 }
@@ -21,7 +23,7 @@ interface ProcessedChatResponse {
   messageId?: string; // 미리 생성된 메시지 ID 저장용
 }
 
-export function useChat({ userId, gradeId, onError, onTypingComplete }: UseChatOptions) {
+export function useChat({ userId, gradeId, clientId, appId, onError, onTypingComplete }: UseChatOptions) {
   const [messages, setMessages] = useState<Message[]>([]);
   const [newMessage, setNewMessage] = useState('');
   const [isTyping, setIsTyping] = useState(false);
@@ -93,7 +95,7 @@ export function useChat({ userId, gradeId, onError, onTypingComplete }: UseChatO
 
   const sendMessage = async (messageContent?: string): Promise<ProcessedChatResponse> => {
     try {
-      const response = await sendChatMessage(messageContent || newMessage, userId, gradeId);
+      const response = await sendChatMessage(messageContent || newMessage, userId, gradeId, clientId, appId);
       return {
         message: response.response,
         toolName: response.tool?.name,

--- a/src/hooks/useQueryParams.ts
+++ b/src/hooks/useQueryParams.ts
@@ -1,0 +1,123 @@
+import { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+
+interface QueryParams {
+  clientId?: string;
+  appId?: string;
+  [key: string]: string | undefined;
+}
+
+// 하드코딩된 기본값 (환경변수 대신 사용)
+const DEFAULT_CLIENT_ID = 'RS000001';
+const DEFAULT_APP_ID = '0001';
+
+/**
+ * URL 쿼리 파라미터를 파싱하여 반환하는 커스텀 훅
+ * 
+ * @returns {QueryParams} 파싱된 쿼리 파라미터 객체
+ * 
+ * @example
+ * // URL: https://example.com?clientId=RS000001&appId=0001
+ * const { clientId, appId } = useQueryParams();
+ * console.log(clientId); // "RS000001"
+ * console.log(appId); // "0001"
+ */
+export function useQueryParams(): QueryParams {
+  const location = useLocation();
+  const [params, setParams] = useState<QueryParams>({});
+
+  useEffect(() => {
+    const searchParams = new URLSearchParams(location.search);
+    const newParams: QueryParams = {};
+
+    // 모든 쿼리 파라미터를 객체로 변환
+    searchParams.forEach((value, key) => {
+      newParams[key] = value;
+    });
+
+    setParams(newParams);
+
+    // 디버깅용 로그
+    if (newParams.clientId || newParams.appId) {
+      console.log('Query params detected:', {
+        clientId: newParams.clientId,
+        appId: newParams.appId
+      });
+    }
+  }, [location.search]);
+
+  return params;
+}
+
+/**
+ * clientId와 appId를 쿼리 파라미터 또는 sessionStorage에서 가져오는 훅
+ * 환경변수는 사용하지 않고, 하드코딩된 기본값 사용
+ * 우선순위: 쿼리 파라미터 > sessionStorage > 기본값
+ * 
+ * @returns {{ clientId: string, appId: string }} clientId와 appId
+ */
+export function useClientConfig() {
+  const queryParams = useQueryParams();
+  const [config, setConfig] = useState({
+    clientId: DEFAULT_CLIENT_ID,
+    appId: DEFAULT_APP_ID
+  });
+
+  useEffect(() => {
+    // 쿼리 파라미터가 있으면 sessionStorage에 저장
+    if (queryParams.clientId || queryParams.appId) {
+      if (queryParams.clientId) {
+        sessionStorage.setItem('clientId', queryParams.clientId);
+      }
+      if (queryParams.appId) {
+        sessionStorage.setItem('appId', queryParams.appId);
+      }
+      
+      console.log('Client config saved to sessionStorage from query params:', {
+        clientId: queryParams.clientId,
+        appId: queryParams.appId
+      });
+    }
+
+    // 우선순위: 쿼리 파라미터 > sessionStorage > 기본값
+    const finalClientId = 
+      queryParams.clientId || 
+      sessionStorage.getItem('clientId') || 
+      DEFAULT_CLIENT_ID;
+    
+    const finalAppId = 
+      queryParams.appId || 
+      sessionStorage.getItem('appId') || 
+      DEFAULT_APP_ID;
+
+    // 설정이 변경되었을 때만 업데이트
+    if (finalClientId !== config.clientId || finalAppId !== config.appId) {
+      console.log('Client config updated:', {
+        clientId: finalClientId,
+        appId: finalAppId,
+        source: queryParams.clientId || queryParams.appId 
+          ? 'query params' 
+          : sessionStorage.getItem('clientId') || sessionStorage.getItem('appId')
+            ? 'sessionStorage'
+            : 'default values'
+      });
+
+      setConfig({
+        clientId: finalClientId,
+        appId: finalAppId
+      });
+    }
+  }, [queryParams.clientId, queryParams.appId]);
+
+  return config;
+}
+
+/**
+ * sessionStorage에 저장된 client 설정을 초기화하는 유틸리티 함수
+ * 테스트나 디버깅 시 사용
+ */
+export function clearClientConfig() {
+  sessionStorage.removeItem('clientId');
+  sessionStorage.removeItem('appId');
+  console.log('Client config cleared from sessionStorage');
+}

--- a/src/locales/ja/common.json
+++ b/src/locales/ja/common.json
@@ -1,6 +1,6 @@
 {
   "common": {
-    "home": "錬成会CS AI Navi",
+    "home": "CS AI Navi",
     "back": "戻る",
     "save": "保存",
     "cancel": "キャンセル",
@@ -18,7 +18,7 @@
   "student": {
     "menu": {
       "home": {
-        "desc": "錬成会メインホームに移動します。"
+        "desc": "メインホームに移動します。"
       },
       "typeCheck": "AI性格タイプ診断",
       "typeCheck.desc": "自分の傾向と学習スタイルを知りましょう",

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Loader2 } from 'lucide-react';
 import { useLocale } from '../contexts/LocaleContext';
+import { useClientConfig } from '../contexts/ClientConfigContext';
 import { ChatLayout } from '../components/templates/ChatLayout';
 import { NavigationHeader } from '../components/organisms/NavigationHeader';
 import { ChatMessage } from '../components/organisms/ChatMessage';
@@ -21,6 +22,7 @@ import { GRADE_LABELS, GRADE_NAMES, type GradeType } from '../shared/constants/g
 
 function MainPage() {
   const { t, isLoading } = useLocale();
+  const { clientId, appId, clientName, schoolName } = useClientConfig(); // Context에서 설정값 가져오기
   const accentColor = getAccentColor();
   const colors = getColorClasses(accentColor);
   const showNavigationHeader = getShowNavigationHeader();
@@ -66,6 +68,8 @@ function MainPage() {
   } = useChat({
     userId: 'Hyunse0001', // 실제 사용자 ID
     gradeId: selectedGrade || 'high', // 선택된 학년 또는 기본값
+    clientId, // 쿼리 파라미터에서 받은 clientId
+    appId, // 쿼리 파라미터에서 받은 appId
     onError: (error) => {
       console.error('Chat error:', error);
     },
@@ -112,12 +116,12 @@ function MainPage() {
   useEffect(() => {
     // 번역이 로드되고 초기화가 아직 되지 않았을 때만 welcome 메시지 추가
     if (!isLoading && !isInitialized.current) {
-      const schoolName = t('chat.schoolName');
+      // 동적 school_name 사용
       const welcomeMessage = t('chat.greeting').replace('{school_name}', schoolName);
       addWelcomeMessage(welcomeMessage);
       isInitialized.current = true;
     }
-  }, [t, addWelcomeMessage, isLoading]);
+  }, [t, addWelcomeMessage, isLoading, schoolName]);
 
   // 최신 LLM 응답 메시지 ID 업데이트
   useEffect(() => {
@@ -359,10 +363,12 @@ function MainPage() {
         showNavigationHeader={showNavigationHeader}
         header={
           <NavigationHeader 
-            title={t('common.home')} 
+            title={`${clientName}CS AI Navi`} 
             accentColor={accentColor}
             showDynamicHeader={true}
-            clientId="default"
+            clientId={clientId}
+            clientName={clientName}
+            schoolName={schoolName}
             onHeaderAction={(action: any) => {
               if (action.type === 'close') {
                 console.log('Header close action triggered');
@@ -416,7 +422,10 @@ function MainPage() {
               {index === 1 && message.type === 'bot' && showGradeSelectionComponent && showGradeSelection && 
                !messages.some(msg => msg.content === 'もどる') && (
                 <div className="mt-4">
-                  <GradeSelection onGradeSelect={handleGradeSelect} />
+                  <GradeSelection 
+                    onGradeSelect={handleGradeSelect} 
+                    clientId={clientId}
+                  />
                 </div>
               )}
               
@@ -424,7 +433,10 @@ function MainPage() {
               {message.type === 'user' && message.content === 'もどる' && showGradeSelectionComponent && 
                index === messages.length - 1 && (
                 <div className="mt-4">
-                  <GradeSelection onGradeSelect={handleGradeSelect} />
+                  <GradeSelection 
+                    onGradeSelect={handleGradeSelect}
+                    clientId={clientId}
+                  />
                 </div>
               )}
               

--- a/src/services/api/chat.ts
+++ b/src/services/api/chat.ts
@@ -29,11 +29,17 @@ export interface ExtendedChatResponse extends ChatResponse {
   llmResponse?: LLMResponse;
 }
 
-export const sendChatMessage = async (message: string, userId: string, gradeId?: string): Promise<ExtendedChatResponse> => {
+export const sendChatMessage = async (
+  message: string, 
+  userId: string, 
+  gradeId?: string,
+  clientId?: string,
+  appId?: string
+): Promise<ExtendedChatResponse> => {
   try {
-    // JWE 토큰 생성 (client_id, app_id 암호화)
+    // JWE 토큰 생성 (client_id, app_id 암호화) - 파라미터로 받은 clientId, appId 사용
     console.log('채팅 메시지 전송 시작 - JWE 토큰 생성 중...');
-    const jweResult = await chatJWEService.createChatJWEToken();
+    const jweResult = await chatJWEService.createChatJWEToken({ clientId, appId });
     
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -52,16 +58,16 @@ export const sendChatMessage = async (message: string, userId: string, gradeId?:
       console.warn('JWE 토큰 생성 실패, 토큰 없이 요청 진행:', jweResult.error);
     }
 
-    // 환경변수에서 clientId, appId 가져오기
-    const clientId = import.meta.env.VITE_CLIENT_ID || 'RS000001';
-    const appId = import.meta.env.VITE_APP_ID || '0001';
+    // 파라미터로 받은 clientId, appId 사용, 없으면 환경변수 사용
+    const finalClientId = clientId || import.meta.env.VITE_CLIENT_ID || 'RS000001';
+    const finalAppId = appId || import.meta.env.VITE_APP_ID || '0001';
     
     const response = await fetchApi('/students/chat', {
       method: 'POST',
       headers,
       body: JSON.stringify({
-        clientId,
-        appId,
+        clientId: finalClientId,
+        appId: finalAppId,
         gradeId: gradeId || 'high', // 기본값 high
         userId,
         message,

--- a/src/services/jwe/chatJWEService.ts
+++ b/src/services/jwe/chatJWEService.ts
@@ -23,12 +23,16 @@ export class ChatJWEService {
    * @param options 토큰 생성 옵션
    * @returns JWE 헤더 생성 결과
    */
-  async createChatJWEToken(options: JWETokenOptions = {}): Promise<JWEHeaderResult> {
+  async createChatJWEToken(options: JWETokenOptions & { clientId?: string; appId?: string } = {}): Promise<JWEHeaderResult> {
     try {
+      // 옵션으로 받은 clientId, appId가 있으면 사용, 없으면 인스턴스 값 사용
+      const finalClientId = options.clientId || this.clientId;
+      const finalAppId = options.appId || this.appId;
+      
       // 채팅용 페이로드 생성
       const payload: ChatJWEPayload = {
-        client_id: this.clientId,
-        app_id: this.appId,
+        client_id: finalClientId,
+        app_id: finalAppId,
         request_type: 'chat',
         userId: `chat-user-${Date.now()}`,
         sessionId: `chat-session-${Date.now()}`,
@@ -46,8 +50,8 @@ export class ChatJWEService {
       const jweService = this.jweServiceIAM;
 
       console.log('채팅 JWE 토큰 생성 시작:', {
-        client_id: this.clientId,
-        app_id: this.appId,
+        client_id: finalClientId,
+        app_id: finalAppId,
         authMode
       });
 


### PR DESCRIPTION
This pull request introduces dynamic client configuration based on `clientId` and `appId`, allowing the app to adapt its branding, school name, and grade selection logic for different clients. It adds a new context for client configuration, updates components to use this context, and refactors relevant logic to support client-specific customization throughout the UI.

**Dynamic Client Configuration and Branding**

* Added `ClientConfigContext` and provider in `src/contexts/ClientConfigContext.tsx`, which initializes and manages client settings (such as `clientId`, `clientName`, and `schoolName`) using URL query parameters, sessionStorage, and default values. This context is now wrapped around the app in `src/App.tsx`. [[1]](diffhunk://#diff-bc10d7bce2cc51ea453b5bcdbec2ef4a6def9d0aecffd69f4031e4e7ad4af86fR1-R150) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R4-R11) [[3]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R25)
* Introduced `src/config/clientMappings.ts` to map `clientId` values to client-specific names and school names, and utility functions to retrieve these values.

**Component Updates for Client Customization**

* Updated `NavigationHeader` and `GradeSelection` components to accept and use `clientId`, `clientName`, and `schoolName` props, enabling dynamic branding and grade selection logic. For example, `GradeSelection` now excludes the "preschool" grade for specific clients. [[1]](diffhunk://#diff-f660f9432ef7329ecbc34e36729536255b07db2b0cd474da4b310188a7b54cc0R15-R16) [[2]](diffhunk://#diff-f660f9432ef7329ecbc34e36729536255b07db2b0cd474da4b310188a7b54cc0R25-R26) [[3]](diffhunk://#diff-f660f9432ef7329ecbc34e36729536255b07db2b0cd474da4b310188a7b54cc0L79-R94) [[4]](diffhunk://#diff-bdb3741a1a64316bed894155b3e45eae7a5d048a0ca57439334302aba0c2ce1cR11-R29) [[5]](diffhunk://#diff-bdb3741a1a64316bed894155b3e45eae7a5d048a0ca57439334302aba0c2ce1cL43-R50)
* Refactored `MainPage` to consume client config from context and pass it to child components, update the welcome message dynamically, and ensure chat and header components reflect client-specific branding. [[1]](diffhunk://#diff-88a8e1f4a094b044c407c596284d254ee9526043b285df233e5895c9ae556640R4) [[2]](diffhunk://#diff-88a8e1f4a094b044c407c596284d254ee9526043b285df233e5895c9ae556640R25) [[3]](diffhunk://#diff-88a8e1f4a094b044c407c596284d254ee9526043b285df233e5895c9ae556640R71-R72) [[4]](diffhunk://#diff-88a8e1f4a094b044c407c596284d254ee9526043b285df233e5895c9ae556640L115-R124) [[5]](diffhunk://#diff-88a8e1f4a094b044c407c596284d254ee9526043b285df233e5895c9ae556640L362-R371) [[6]](diffhunk://#diff-88a8e1f4a094b044c407c596284d254ee9526043b285df233e5895c9ae556640L419-R439)

**API and Hook Changes**

* Updated the `useChat` hook and its options to accept `clientId` and `appId`, ensuring these values are sent with chat requests for client-specific processing. [[1]](diffhunk://#diff-88f83f1d7d56974e722ee0a0e4bdb6c0018cbd2759362499c38313539e68736cR12-R13) [[2]](diffhunk://#diff-88f83f1d7d56974e722ee0a0e4bdb6c0018cbd2759362499c38313539e68736cL24-R26) [[3]](diffhunk://#diff-88f83f1d7d56974e722ee0a0e4bdb6c0018cbd2759362499c38313539e68736cL96-R98)
* Added a new `useQueryParams` hook in `src/hooks/useQueryParams.ts` to parse URL parameters and support client config initialization and updates.

**Branding and Localization Adjustments**

* Changed app title and Japanese localization strings to remove hardcoded client names, making them generic and ready for dynamic substitution. [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L7-R7) [[2]](diffhunk://#diff-eb88db228bcfaf1503636ba2b3e23445615a527d4cfd2fb8e1305818800a0026L3-R3) [[3]](diffhunk://#diff-eb88db228bcfaf1503636ba2b3e23445615a527d4cfd2fb8e1305818800a0026L21-R21)