### PR TITLE
feat: MM000002 클라이언트 전용 메뉴 및 CTA 링크 설정

### DIFF
--- a/src/components/molecules/CTAButtons/CTAButtons.tsx
+++ b/src/components/molecules/CTAButtons/CTAButtons.tsx
@@ -8,12 +8,13 @@ interface CTAButtonsProps {
   onSubClick: () => void;
   show: boolean;
   accentColor?: AccentColor;
+  clientId?: string;
 }
 
-export function CTAButtons({ onMainClick, onSubClick, show, accentColor }: CTAButtonsProps) {
+export function CTAButtons({ onMainClick, onSubClick, show, accentColor, clientId }: CTAButtonsProps) {
   const defaultAccentColor = getAccentColor();
   const colors = getColorClasses(accentColor || defaultAccentColor);
-  const ctaConfig = getCTAButtonsConfig();
+  const ctaConfig = getCTAButtonsConfig(clientId);
 
   if (!show) return null;
 

--- a/src/components/organisms/ChatMessage/ChatMessage.tsx
+++ b/src/components/organisms/ChatMessage/ChatMessage.tsx
@@ -18,6 +18,7 @@ interface ChatMessageProps {
   onMainCTAClick?: () => void;
   onSubCTAClick?: () => void;
   onCTADisplayed?: () => void; // CTA 표시 완료 후 스크롤 콜백
+  clientId?: string; // clientId 추가
 }
 
 export function ChatMessage({ 
@@ -30,7 +31,8 @@ export function ChatMessage({
   showCTAAfterComplete = false,
   onMainCTAClick,
   onSubCTAClick,
-  onCTADisplayed
+  onCTADisplayed,
+  clientId
 }: ChatMessageProps) {
   const { locale } = useLocale();
   const accentColor = getAccentColor();
@@ -53,6 +55,7 @@ export function ChatMessage({
             onMainCTAClick={onMainCTAClick}
             onSubCTAClick={onSubCTAClick}
             onCTADisplayed={onCTADisplayed}
+            clientId={clientId}
           />
         ) : (
           <ChatBubble

--- a/src/components/organisms/LLMResponseGroup/LLMResponseGroup.tsx
+++ b/src/components/organisms/LLMResponseGroup/LLMResponseGroup.tsx
@@ -14,6 +14,7 @@ interface LLMResponseGroupProps {
   onSubCTAClick?: () => void;
   showCTAAfterComplete?: boolean; // 모든 버블 완료 후 CTA 표시 여부
   onCTADisplayed?: () => void; // CTA 표시 완료 후 스크롤 콜백
+  clientId?: string; // clientId 추가
 }
 
 export function LLMResponseGroup({ 
@@ -24,7 +25,8 @@ export function LLMResponseGroup({
   onMainCTAClick,
   onSubCTAClick,
   showCTAAfterComplete = false,
-  onCTADisplayed
+  onCTADisplayed,
+  clientId
 }: LLMResponseGroupProps) {
   const [currentBubbleIndex, setCurrentBubbleIndex] = useState(0);
   const [completedBubbles, setCompletedBubbles] = useState<number[]>([]);
@@ -136,6 +138,7 @@ export function LLMResponseGroup({
           onMainClick={handleMainCTA}
           onSubClick={handleSubCTA}
           accentColor={accentColor}
+          clientId={clientId}
         />
       )}
     </div>

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -9,6 +9,8 @@ import { ChatInput } from '../components/organisms/ChatInput';
 import { QuickReply } from '../components/organisms/QuickReply';
 import { FAQCategory } from '../components/organisms/FAQCategory';
 import { TopQuestions } from '../components/organisms/TopQuestions';
+import { MenuModal } from '../components/organisms/MenuModal';
+import { MenuService } from '../services/menuService';
 import { isIOS } from '../utils/device';
 import { TypingIndicator } from '../components/molecules/TypingIndicator';
 import { IOSViewportDebug } from '../components/molecules/IOSViewportDebug';
@@ -382,6 +384,7 @@ function MainPage() {
             onChange={setNewMessage}
             onSend={handleSendClick}
             disabled={isTyping || (showGradeSelection && !selectedGrade)}
+            clientId={clientId}
             placeholder={
               showGradeSelection && !selectedGrade 
                 ? 'まずは学年を選択してください'
@@ -409,6 +412,7 @@ function MainPage() {
                   message={message} 
                   hideAvatar={message.type === 'bot' && !isFirstBotMessage}
                   llmResponse={message.llmResponse}
+                  clientId={clientId}
                   // 최신 LLM 응답에서만 CTA 버튼 표시
                   {...(message.llmResponse ? {
                     showCTAAfterComplete: message.id === latestCTAMessageId && !hideAllCTA,
@@ -512,6 +516,7 @@ function MainPage() {
               hideAvatar={messages.some(m => m.type === 'bot')}
               llmResponse={currentlyTyping.llmResponse}
               enableLLMTyping={true}
+              clientId={clientId}
             />
           )}
           

--- a/src/services/menuService.ts
+++ b/src/services/menuService.ts
@@ -121,6 +121,49 @@ const clientMenuConfigs: Record<string, MenuConfig> = {
       action: 'navigate',
       url: '/demo'
     }
+  },
+  // MM000002 (名門会) 전용 설정
+  'MM000002': {
+    items: [
+      {
+        id: 'ai-faq',
+        icon: {
+          type: 'component',
+          value: 'AiChatbotIcon'
+        },
+        label: 'AI FAQ',
+        action: 'navigate',
+        url: '/faq',
+        disabled: false
+      },
+      {
+        id: 'request-materials',
+        icon: {
+          type: 'lucide',
+          value: 'FileText'
+        },
+        label: '資料請求',
+        action: 'external-link',
+        url: 'https://meimonkai.co.jp/request/',  // 名門会 자료청구 링크
+        disabled: false
+      },
+      {
+        id: 'ai-consultation',
+        icon: {
+          type: 'lucide',
+          value: 'Phone'
+        },
+        label: 'AI電話相談',
+        action: 'navigate',
+        url: '/consultation',
+        disabled: true
+      }
+    ],
+    cta: {
+      label: '無料体験に応募する',
+      action: 'external-link',
+      url: 'https://meimonkai.co.jp/request/'  // 名門会 무료체험 링크
+    }
   }
 };
 

--- a/src/shared/config/app.config.ts
+++ b/src/shared/config/app.config.ts
@@ -79,7 +79,27 @@ export interface CTAButtonsConfig {
   sub: CTAButtonConfig;
 }
 
-export const getCTAButtonsConfig = (): CTAButtonsConfig => {
+export const getCTAButtonsConfig = (clientId?: string): CTAButtonsConfig => {
+  // MM000002 (名門会) 전용 설정
+  if (clientId === 'MM000002') {
+    return {
+      main: {
+        title: "資料請求する",
+        action: {
+          type: "link",
+          detail: "https://meimonkai.co.jp/request/"  // 名門会 자료청구 링크
+        }
+      },
+      sub: {
+        title: "もう少し質問する",
+        action: {
+          type: "FAQ",
+          detail: ""
+        }
+      }
+    };
+  }
+  
   const ctaButtonsConfig = import.meta.env.VITE_CTA_BUTTONS;
   
   try {


### PR DESCRIPTION
## 개요
MM000002 (名門会) 클라이언트를 위한 전용 메뉴 및 CTA 링크 설정을 추가했습니다.

## 변경사항
### 1. 메뉴 설정 (`menuService.ts`)
- MM000002 클라이언트 전용 메뉴 구성 추가
- 자료청구 링크: `https://meimonkai.co.jp/request/`
- 무료체험 CTA: `https://meimonkai.co.jp/request/`

### 2. CTA 버튼 설정 (`app.config.ts`)
- MM000002 클라이언트 전용 CTA 설정 추가
- 자료청구 버튼 링크 통일

### 3. 컴포넌트 수정
- `CTAButtons`: clientId 파라미터 추가
- `LLMResponseGroup`: clientId 전달
- `ChatMessage`: clientId 전달
- `MainPage`: ChatInput에 clientId 전달

## 테스트 방법
```bash
# 개발 서버 실행
npm run dev

# MM000002 클라이언트로 접속
http://localhost:5173/?clientId=MM000002&appId=0001
```

## 확인사항
- ✅ 메뉴의 "資料請求" 링크가 名門会 페이지로 연결
- ✅ CTA "無料体験に応募する" 링크가 名門会 페이지로 연결
- ✅ 챗봇 내 "資料請求する" 버튼이 名門会 페이지로 연결
- ✅ 모든 링크가 `https://meimonkai.co.jp/request/`로 통일

## 관련 이슈
- 클라이언트별 맞춤 설정 지원