### PR TITLE
feat: 환경변수 기반 카테고리 API 연동 구현 (#94)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@ VITE_SHOW_GRADE_SELECTION=true
 
 # FAQ API 설정
 VITE_USE_FAQ_API=false
+VITE_USE_CATEGORY_API=false  # 카테고리 API 사용 여부
 VITE_CONTENT_CONFIG_API_URL=https://content-config-dev.meeta.jp/v1
 
 # AI 음성 상담 설정

--- a/src/components/organisms/FAQCategory/FAQCategory.tsx
+++ b/src/components/organisms/FAQCategory/FAQCategory.tsx
@@ -28,6 +28,10 @@ export interface FAQCategoryItem {
   iconConfig?: IconConfig;
   /** @deprecated 백워드 호환성을 위해 유지. iconConfig 사용을 권장합니다. */
   icon?: React.ReactNode;
+  /** API에서 가져온 카테고리 이름 (API 사용 시) */
+  displayName?: string;
+  /** API에서 가져온 이모지 아이콘 (API 사용 시) */
+  emojiIcon?: string;
 }
 
 interface FAQCategoryProps {
@@ -62,6 +66,13 @@ const createDefaultCategories = (): FAQCategoryItem[] => {
  * @returns 렌더링할 아이콘 JSX 엘리먼트
  */
 const renderCategoryIcon = (category: FAQCategoryItem): React.ReactNode => {
+  // API에서 가져온 이모지 아이콘 우선 표시
+  if (category.emojiIcon) {
+    return (
+      <span className="text-base">{category.emojiIcon}</span>
+    );
+  }
+  
   if (category.iconConfig) {
     return (
       <Icon 
@@ -156,7 +167,7 @@ const CategoryButton: React.FC<CategoryButtonProps> = ({
         {renderCategoryIcon(category)}
       </div>
       <span className={STYLES.TEXT_SPAN}>
-        {t(category.textKey)}
+        {category.displayName || t(category.textKey)}
       </span>
     </button>
   </div>

--- a/src/components/organisms/TopQuestions/TopQuestions.tsx
+++ b/src/components/organisms/TopQuestions/TopQuestions.tsx
@@ -35,7 +35,7 @@ const sortQuestionsByBest = (questions: Question[]): Question[] => {
 };
 
 interface TopQuestionsProps {
-  categoryId: CategoryType;
+  categoryId: CategoryType | string;
   categoryTitle: string;
   grade: GradeType;
   onQuestionSelect: (question: string) => void;
@@ -84,16 +84,22 @@ export function TopQuestions({
           }
         } else {
           // FAQ API가 비활성화된 경우 기존 로컬 데이터 사용
-          const gradeQuestions = GRADE_CATEGORY_QUESTIONS[grade][categoryId];
-          
-          if (gradeQuestions && gradeQuestions.length > 0) {
-            // 베스트 질문 우선 정렬
-            const sortedQuestions = sortQuestionsByBest(gradeQuestions);
+          // categoryId가 CategoryType인 경우만 로컬 데이터 사용
+          if (typeof categoryId === 'string' && !categoryId.startsWith('CAT')) {
+            const gradeQuestions = GRADE_CATEGORY_QUESTIONS[grade][categoryId as CategoryType];
             
-            // 질문 텍스트만 추출
-            const questionTexts = sortedQuestions.map(q => q.text);
-            setQuestions(questionTexts);
+            if (gradeQuestions && gradeQuestions.length > 0) {
+              // 베스트 질문 우선 정렬
+              const sortedQuestions = sortQuestionsByBest(gradeQuestions);
+              
+              // 질문 텍스트만 추출
+              const questionTexts = sortedQuestions.map(q => q.text);
+              setQuestions(questionTexts);
+            } else {
+              setQuestions([]);
+            }
           } else {
+            // API categoryId인 경우 로컬 데이터가 없음
             setQuestions([]);
           }
         }
@@ -103,12 +109,17 @@ export function TopQuestions({
         
         // 에러 발생 시 로컬 데이터로 폴백
         try {
-          const gradeQuestions = GRADE_CATEGORY_QUESTIONS[grade][categoryId];
-          if (gradeQuestions && gradeQuestions.length > 0) {
-            const sortedQuestions = sortQuestionsByBest(gradeQuestions);
-            const questionTexts = sortedQuestions.map(q => q.text);
-            setQuestions(questionTexts);
+          if (typeof categoryId === 'string' && !categoryId.startsWith('CAT')) {
+            const gradeQuestions = GRADE_CATEGORY_QUESTIONS[grade][categoryId as CategoryType];
+            if (gradeQuestions && gradeQuestions.length > 0) {
+              const sortedQuestions = sortQuestionsByBest(gradeQuestions);
+              const questionTexts = sortedQuestions.map(q => q.text);
+              setQuestions(questionTexts);
+            } else {
+              setQuestions([]);
+            }
           } else {
+            // API categoryId인 경우 로컬 데이터가 없음
             setQuestions([]);
           }
         } catch (fallbackErr) {

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -7,7 +7,7 @@ import { NavigationHeader } from '../components/organisms/NavigationHeader';
 import { ChatMessage } from '../components/organisms/ChatMessage';
 import { ChatInput } from '../components/organisms/ChatInput';
 import { QuickReply } from '../components/organisms/QuickReply';
-import { FAQCategory } from '../components/organisms/FAQCategory';
+import { FAQCategory, FAQCategoryItem } from '../components/organisms/FAQCategory';
 import { TopQuestions } from '../components/organisms/TopQuestions';
 import { VoiceInputModal } from '../components/organisms/VoiceInputModal/VoiceInputModal';
 import { MenuModal } from '../components/organisms/MenuModal';
@@ -23,6 +23,8 @@ import { GradeSelection } from '../components/organisms/GradeSelection';
 import { GradeQuickReply } from '../components/organisms/GradeQuickReply';
 import { GRADE_LABELS, GRADE_NAMES, type GradeType } from '../shared/constants/grade.constants';
 import type { Message } from '../types';
+import { getCategories, isCategoryApiEnabled } from '../services/api/category';
+import { CategoryItem } from '../types/api/category.types';
 
 function MainPage() {
   const { t, isLoading } = useLocale();
@@ -36,6 +38,10 @@ function MainPage() {
   const [showFAQCategories, setShowFAQCategories] = useState(false);
   const [waitingForFAQCategories, setWaitingForFAQCategories] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState<any>(null);
+  
+  // API 카테고리 관련 상태
+  const [apiCategories, setApiCategories] = useState<FAQCategoryItem[] | null>(null);
+  const [categoriesLoading, setCategoriesLoading] = useState(false);
   
   // 온보딩 관련 상태
   const [showGradeSelectionComponent, setShowGradeSelectionComponent] = useState(false);
@@ -121,6 +127,35 @@ function MainPage() {
       isInitialized.current = true;
     }
   }, [t, addWelcomeMessage, isLoading, schoolName]);
+
+  // 카테고리 API 호출
+  useEffect(() => {
+    if (isCategoryApiEnabled() && clientId) {
+      setCategoriesLoading(true);
+      getCategories(clientId, true)
+        .then(response => {
+          if (response && response.items) {
+            // API 응답을 FAQCategoryItem 형식으로 변환
+            const convertedCategories: FAQCategoryItem[] = response.items
+              .sort((a, b) => a.displayOrder - b.displayOrder)
+              .map(item => ({
+                id: item.categoryId,
+                textKey: '', // API 사용 시에는 사용하지 않음
+                valueKey: item.categoryId, // TopQuestions API에 전달할 categoryId
+                displayName: item.categoryName,
+                emojiIcon: item.icon
+              }));
+            setApiCategories(convertedCategories);
+          }
+        })
+        .catch(error => {
+          console.error('Failed to load categories:', error);
+        })
+        .finally(() => {
+          setCategoriesLoading(false);
+        });
+    }
+  }, [clientId]);
 
   // 최신 LLM 응답 메시지 ID 업데이트
   useEffect(() => {
@@ -220,8 +255,8 @@ function MainPage() {
     }, 100);
   };
 
-  const handleFAQCategorySelect = (category: any) => {
-    const categoryTitle = t(category.textKey);
+  const handleFAQCategorySelect = (category: FAQCategoryItem) => {
+    const categoryTitle = category.displayName || t(category.textKey);
     const categorySelectedMessage = t('chat.faq.categorySelected', { category: categoryTitle });
     
     // 이전 컴포넌트들 비활성화
@@ -526,6 +561,7 @@ function MainPage() {
               {isComponentActive('faqCategories', message.id) && showFAQCategories && (
                 <div className="mt-4">
                   <FAQCategory 
+                    categories={apiCategories || undefined}
                     onCategorySelect={handleFAQCategorySelect}
                   />
                 </div>
@@ -534,8 +570,8 @@ function MainPage() {
               {selectedCategory && isComponentActive('topQuestions', message.id) && (
                 <div className="mt-4">
                   <TopQuestions
-                    categoryId={selectedCategory.id}
-                    categoryTitle={t(selectedCategory.textKey)}
+                    categoryId={selectedCategory.valueKey || selectedCategory.id}
+                    categoryTitle={selectedCategory.displayName || t(selectedCategory.textKey)}
                     grade={selectedGrade || 'high'}
                     onQuestionSelect={handleTopQuestionSelect}
                     onBackToCategories={handleBackToCategories}

--- a/src/services/api/category.ts
+++ b/src/services/api/category.ts
@@ -1,0 +1,62 @@
+/**
+ * 카테고리 API 서비스
+ * Content Config Service의 카테고리 관련 API 호출을 처리합니다.
+ */
+
+import { CategoryApiResponse, CategoryRequest } from '../../types/api/category.types';
+
+const CONTENT_CONFIG_API_URL = import.meta.env.VITE_CONTENT_CONFIG_API_URL || 'https://content-config-dev.meeta.jp/v1';
+const USE_CATEGORY_API = import.meta.env.VITE_USE_CATEGORY_API === 'true';
+
+/**
+ * 카테고리 목록을 가져옵니다
+ * @param clientId - 클라이언트 ID
+ * @param isActive - 활성 카테고리만 조회 (기본값: true)
+ * @returns 카테고리 목록 또는 null (API 비활성화 또는 오류 시)
+ */
+export async function getCategories(
+  clientId: string = 'RS000001',
+  isActive: boolean = true
+): Promise<CategoryApiResponse | null> {
+  if (!USE_CATEGORY_API) {
+    console.log('Category API is disabled');
+    return null;
+  }
+
+  try {
+    const params = new URLSearchParams({
+      clientId,
+      isActive: isActive.toString()
+    });
+
+    const url = `${CONTENT_CONFIG_API_URL}/categories?${params}`;
+    console.log('Fetching categories from:', url);
+
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      }
+    });
+
+    if (!response.ok) {
+      console.error('Category API error:', response.status, response.statusText);
+      return null;
+    }
+
+    const data = await response.json();
+    console.log('Categories fetched successfully:', data);
+    return data as CategoryApiResponse;
+  } catch (error) {
+    console.error('Failed to fetch categories:', error);
+    return null;
+  }
+}
+
+/**
+ * 카테고리 API 사용 여부를 확인합니다
+ */
+export function isCategoryApiEnabled(): boolean {
+  return USE_CATEGORY_API;
+}

--- a/src/services/api/faq.ts
+++ b/src/services/api/faq.ts
@@ -62,13 +62,13 @@ export async function getQuickReplyQuestions(
 /**
  * Fetch top 5 questions for Top Questions component
  * @param grade - Grade level (preschool, elementary, middle, high)
- * @param categoryId - Category ID (curriculum, schedule, pricing)
+ * @param categoryId - Category ID (curriculum, schedule, pricing or API categoryId like CAT202508150001)
  * @param clientId - Client ID (defaults to RS000001)
  * @returns Promise with top questions
  */
 export async function getTopQuestions(
   grade: GradeType,
-  categoryId: CategoryType,
+  categoryId: CategoryType | string,
   clientId: string = 'RS000001'
 ): Promise<TopQuestionsApiResponse | null> {
   if (!USE_FAQ_API) {
@@ -76,11 +76,18 @@ export async function getTopQuestions(
   }
 
   try {
-    // Map category to API categoryId
-    const apiCategoryId = CATEGORY_ID_MAP[categoryId];
-    if (!apiCategoryId) {
-      console.error('Invalid category ID:', categoryId);
-      return null;
+    // API에서 받은 categoryId(CAT로 시작)인 경우 직접 사용, 아니면 매핑 사용
+    let apiCategoryId: string;
+    if (categoryId.startsWith('CAT')) {
+      // API에서 받은 categoryId 직접 사용
+      apiCategoryId = categoryId;
+    } else {
+      // 기존 매핑 사용
+      apiCategoryId = CATEGORY_ID_MAP[categoryId as CategoryType];
+      if (!apiCategoryId) {
+        console.error('Invalid category ID:', categoryId);
+        return null;
+      }
     }
 
     const params = new URLSearchParams({

--- a/src/types/api/category.types.ts
+++ b/src/types/api/category.types.ts
@@ -1,0 +1,42 @@
+/**
+ * 카테고리 API 관련 타입 정의
+ */
+
+/**
+ * 카테고리 아이템
+ */
+export interface CategoryItem {
+  categoryId: string;
+  categoryName: string;
+  description: string;
+  displayOrder: number;
+  icon: string;
+  color: string | null;
+  targetAttributes: string[];
+  isActive: boolean;
+  clientId: string;
+  faqCount: number;
+  createdAt: string;
+  updatedAt: string;
+  createdBy: string;
+  updatedBy: string;
+}
+
+/**
+ * 카테고리 API 응답
+ */
+export interface CategoryApiResponse {
+  items: CategoryItem[];
+  totalCount: number;
+  nextToken: string | null;
+}
+
+/**
+ * 카테고리 요청 파라미터
+ */
+export interface CategoryRequest {
+  clientId: string;
+  isActive?: boolean;
+  limit?: number;
+  nextToken?: string;
+}


### PR DESCRIPTION
## 📋 개요
환경변수 `VITE_USE_CATEGORY_API=true` 설정 시 외부 API를 통해 카테고리 목록을 동적으로 가져오도록 구현했습니다.

## 🎯 구현 내용

### 1. 카테고리 API 서비스 구현
- `/categories` 엔드포인트 연동 (`src/services/api/category.ts`)
- API 응답을 FAQCategoryItem 형식으로 변환
- 환경변수로 기능 토글 지원

### 2. 컴포넌트 수정
- **MainPage**: useEffect로 카테고리 API 호출 후 props로 전달 (옵션 2 패턴)
- **FAQCategory**: API 카테고리 데이터 표시 지원 (이모지 아이콘, displayName)
- **TopQuestions**: API categoryId 직접 사용 지원

### 3. FAQ API 호출 로직 개선
- `CAT`로 시작하는 categoryId는 직접 사용
- 기존 categoryId는 CATEGORY_ID_MAP 매핑 사용
- 하위 호환성 유지

## 🔧 적용한 개념

### 1. **Props Drilling 패턴**
- MainPage에서 API 호출 → FAQCategory로 props 전달
- 중앙화된 데이터 관리로 일관성 확보

### 2. **Graceful Degradation**
- API 실패 시 하드코딩된 기본 카테고리로 폴백
- 환경변수 미설정 시 기존 로직 유지

### 3. **타입 안전성**
- `CategoryType | string` 유니온 타입으로 유연성 확보
- 타입 가드(`startsWith('CAT')`)로 런타임 안전성 보장

## 💡 시행착오 및 해결

### 문제 1: TopQuestions에서 "Invalid category ID" 에러
- **원인**: API categoryId(`CAT202508150001`)가 CATEGORY_ID_MAP에 없음
- **해결**: `startsWith('CAT')` 체크로 API categoryId 직접 사용

### 문제 2: TypeScript 타입 에러
- **원인**: `GRADE_CATEGORY_QUESTIONS[grade][categoryId]`에서 string 인덱싱 불가
- **해결**: 타입 가드와 as 어서션으로 CategoryType 보장

## 📚 습득한 도메인 지식

1. **Content Config Service API 구조**
   - `categoryId`: `CAT` 접두사 + 타임스탬프 형식
   - `displayOrder`: 카테고리 정렬 순서
   - `icon`: 이모지 직접 제공

2. **FAQ 시스템 아키텍처**
   - 카테고리 → Top Questions → LLM 응답의 3단계 구조
   - 각 단계별 API 독립적 운영

## ⚠️ 향후 주의사항

1. **환경변수 설정**
   ```env
   VITE_USE_CATEGORY_API=true  # 카테고리 API 사용
   VITE_USE_FAQ_API=true        # FAQ API 사용 (기존)
   VITE_CONTENT_CONFIG_API_URL=http://127.0.0.1:8003
   ```

2. **API 의존성**
   - 카테고리 API와 FAQ API는 독립적으로 토글 가능
   - 둘 다 활성화 시 최적의 사용자 경험

3. **타입 체크**
   - 새로운 카테고리 추가 시 `CategoryType` 확장 불필요
   - API categoryId는 string으로 처리

## ✅ 테스트 완료
- [x] API 카테고리 표시 정상
- [x] 카테고리 선택 → TopQuestions 호출 정상
- [x] 환경변수 false 시 기존 로직 동작
- [x] API 오류 시 폴백 동작

## 🔗 관련 이슈
Closes #94

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>