### PR TITLE
fix: 모바일 브라우저 음성 재생 문제 해결

### DIFF
--- a/src/components/organisms/VoiceInputModal/VoiceInputModal.tsx
+++ b/src/components/organisms/VoiceInputModal/VoiceInputModal.tsx
@@ -227,6 +227,11 @@ export function VoiceInputModal({
 
   // Handle recording start
   const startRecording = async () => {
+    // 데모 모드에서 모바일 오디오 컨텍스트 활성화
+    if (isDemoMode) {
+      await demoVoiceService.activateAudioContext();
+    }
+    
     if (!recognitionService.current) {
       setError('音声認識サービスが利用できません');
       return;

--- a/src/services/demo/demoVoiceService.ts
+++ b/src/services/demo/demoVoiceService.ts
@@ -186,6 +186,25 @@ export class DemoVoiceService {
   }
   
   /**
+   * 오디오 컨텍스트 활성화 (모바일 대응)
+   * 사용자 상호작용 시점에 호출하여 오디오 재생 권한 획득
+   */
+  async activateAudioContext(): Promise<void> {
+    try {
+      // 무음 데이터 URI (1초의 무음)
+      const silentAudioData = 'data:audio/wav;base64,UklGRigAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQQAAAAAAAA=';
+      const audio = new Audio(silentAudioData);
+      audio.volume = 0.01;
+      
+      // 무음 재생으로 오디오 컨텍스트 활성화
+      await audio.play();
+      console.log('[Demo Mode] Audio context activated');
+    } catch (error) {
+      console.warn('[Demo Mode] Failed to activate audio context:', error);
+    }
+  }
+
+  /**
    * Audio 요소를 사용한 직접 재생 (CORS 우회)
    */
   async playAudioDirect(voiceFile: string): Promise<void> {


### PR DESCRIPTION
## 🐛 문제 
모바일 브라우저에서 데모 모드 음성이 재생되지 않는 문제

## 🔧 해결 방법
무음 트릭(Silent Audio Trick)을 사용하여 오디오 컨텍스트 활성화

## 📱 구현 내용

### 1. `activateAudioContext` 메서드 추가
- 무음 데이터 URI를 사용한 오디오 재생
- 사용자 상호작용 시점에 오디오 컨텍스트 활성화

### 2. 마이크 버튼 클릭 시 활성화
- `startRecording` 시작 시 오디오 컨텍스트 활성화
- 이후 음성 재생이 정상적으로 동작

## 🌐 브라우저 자동 재생 정책

### 문제 원인
- **iOS Safari**: 사용자 상호작용 없이 오디오 재생 차단
- **Android Chrome**: 자동 재생 정책으로 인한 제한

### 해결 원리
1. 사용자가 마이크 버튼 클릭 (사용자 상호작용)
2. 무음 오디오 재생으로 오디오 컨텍스트 활성화
3. 이후 음성 파일 재생 가능

## ✅ 테스트
- [x] iOS Safari에서 음성 재생 확인
- [x] Android Chrome에서 음성 재생 확인
- [x] 데스크톱 브라우저 정상 동작 확인

## 📝 참고
- 사용자가 브라우저 설정에서 자동 재생을 허용할 수도 있지만, 코드로 해결하는 것이 더 나은 UX 제공
- 무음 트릭은 널리 사용되는 웹 오디오 우회 기법