### PR TITLE
fix: FAQ 카테고리 아이콘 렌더링 에러 수정

### DIFF
--- a/src/components/organisms/FAQCategory/FAQCategory.tsx
+++ b/src/components/organisms/FAQCategory/FAQCategory.tsx
@@ -66,13 +66,14 @@ const createDefaultCategories = (): FAQCategoryItem[] => {
  * @returns 렌더링할 아이콘 JSX 엘리먼트
  */
 const renderCategoryIcon = (category: FAQCategoryItem): React.ReactNode => {
-  // API에서 가져온 이모지 아이콘 우선 표시
-  if (category.emojiIcon) {
+  // 1. API에서 가져온 이모지 아이콘 우선 표시 (타입 안전성 확보)
+  if (category.emojiIcon && typeof category.emojiIcon === 'string') {
     return (
       <span className="text-base">{category.emojiIcon}</span>
     );
   }
   
+  // 2. iconConfig 처리
   if (category.iconConfig) {
     return (
       <Icon 
@@ -82,12 +83,37 @@ const renderCategoryIcon = (category: FAQCategoryItem): React.ReactNode => {
     );
   }
   
-  // 백워드 호환성 지원
+  // 3. 백워드 호환성 지원 - 레거시 icon 필드 처리
   if (category.icon) {
-    return category.icon;
+    // 객체인 경우 (API 응답의 {type, value, color} 형태)
+    if (typeof category.icon === 'object' && 'type' in category.icon && 'value' in category.icon) {
+      const iconObj = category.icon as {type: string, value: string, color?: string | null};
+      
+      if (iconObj.type === 'emoji' && typeof iconObj.value === 'string') {
+        return <span className="text-base">{iconObj.value}</span>;
+      }
+      
+      if (iconObj.type === 'lucide' && typeof iconObj.value === 'string') {
+        return (
+          <Icon 
+            config={{
+              type: 'lucide',
+              value: iconObj.value
+            }} 
+            className={STYLES.ICON}
+          />
+        );
+      }
+      
+      // 알 수 없는 객체 타입의 경우 경고하고 기본 아이콘 사용
+      console.warn('Unknown icon object format:', iconObj);
+    } else {
+      // 기존 React.ReactNode 처리
+      return category.icon;
+    }
   }
   
-  // 기본 아이콘
+  // 4. 기본 아이콘
   return <MessageCircleMore className={STYLES.ICON} />;
 };
 

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -1,0 +1,53 @@
+/**
+ * API 관련 타입 정의
+ */
+
+/**
+ * 백엔드 FAQ 카테고리 API 응답의 아이콘 타입
+ */
+export interface BackendIconResponse {
+  type: 'emoji' | 'lucide' | 'custom';
+  value: string;
+  color: string | null;
+}
+
+/**
+ * 백엔드 FAQ 카테고리 API 응답 타입
+ */
+export interface BackendCategoryResponse {
+  categoryId: string;
+  clientId: string;
+  categoryName: string;
+  originName: string;
+  description: string;
+  displayOrder: number;
+  icon: BackendIconResponse | null;
+  color: string | null;
+  targetAttributes: string[];
+  isActive: boolean;
+  faqCount: number;
+  createdAt: string;
+  updatedAt: string;
+  createdBy: string;
+  updatedBy: string;
+}
+
+/**
+ * 백엔드 FAQ 카테고리 목록 API 응답 타입
+ */
+export interface BackendCategoriesResponse {
+  items: BackendCategoryResponse[];
+  totalCount: number;
+  nextToken: string | null;
+}
+
+/**
+ * API 에러 응답 타입
+ */
+export interface ApiErrorResponse {
+  error: {
+    code: string;
+    message: string;
+    details?: unknown;
+  };
+}

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -1,0 +1,5 @@
+/**
+ * 공통 타입 정의 exports
+ */
+
+export * from './api';

--- a/src/shared/utils/faqCategoryTransformer.ts
+++ b/src/shared/utils/faqCategoryTransformer.ts
@@ -1,0 +1,106 @@
+/**
+ * FAQ 카테고리 데이터 변환 유틸리티
+ */
+
+import type { BackendCategoryResponse, BackendIconResponse } from '../types/api';
+import type { FAQCategoryItem } from '../../components/organisms/FAQCategory/FAQCategory';
+import type { IconConfig } from '../config/iconConfig';
+
+/**
+ * 백엔드 아이콘 응답을 프론트엔드 형식으로 변환
+ */
+const transformIconResponse = (icon: BackendIconResponse | null): {
+  emojiIcon?: string;
+  iconConfig?: IconConfig;
+} => {
+  if (!icon) {
+    return {};
+  }
+
+  switch (icon.type) {
+    case 'emoji':
+      return {
+        emojiIcon: icon.value
+      };
+    
+    case 'lucide':
+      return {
+        iconConfig: {
+          type: 'lucide',
+          value: icon.value,
+          ...(icon.color && { color: icon.color })
+        }
+      };
+    
+    case 'custom':
+      // custom 타입은 현재 IconConfig에서 지원하지 않으므로 lucide로 fallback
+      console.warn('Custom icon type not supported, falling back to lucide');
+      return {
+        iconConfig: {
+          type: 'lucide',
+          value: 'HelpCircle', // 기본 아이콘으로 fallback
+        }
+      };
+    
+    default:
+      console.warn('Unknown icon type:', icon.type);
+      return {};
+  }
+};
+
+/**
+ * 백엔드 FAQ 카테고리 응답을 프론트엔드 형식으로 변환
+ */
+export const transformBackendCategoryResponse = (
+  backendData: BackendCategoryResponse[]
+): FAQCategoryItem[] => {
+  return backendData.map(item => {
+    const iconProps = transformIconResponse(item.icon);
+    
+    return {
+      id: item.categoryId,
+      textKey: `category.${item.categoryId}`,
+      valueKey: item.categoryId,
+      displayName: item.categoryName,
+      ...iconProps
+    };
+  });
+};
+
+/**
+ * 안전한 아이콘 렌더링을 위한 타입 가드
+ */
+export const isValidEmojiIcon = (icon: unknown): icon is string => {
+  return typeof icon === 'string' && icon.length > 0;
+};
+
+/**
+ * 안전한 IconConfig 타입 가드
+ */
+export const isValidIconConfig = (config: unknown): config is IconConfig => {
+  return (
+    config &&
+    typeof config === 'object' &&
+    typeof config.type === 'string' &&
+    typeof config.value === 'string'
+  );
+};
+
+/**
+ * 레거시 icon 객체 처리를 위한 타입 가드 및 변환
+ */
+export const transformLegacyIconObject = (icon: unknown): {
+  emojiIcon?: string;
+  iconConfig?: IconConfig;
+} => {
+  if (!icon || typeof icon !== 'object') {
+    return {};
+  }
+
+  // {type, value, color} 형태의 객체 처리
+  if ('type' in icon && 'value' in icon) {
+    return transformIconResponse(icon as BackendIconResponse);
+  }
+
+  return {};
+};


### PR DESCRIPTION
## Summary
API 응답에서 `icon` 필드가 `{type, value, color}` 객체 형태로 변경되어 React child로 직접 렌더링 시 에러가 발생하는 문제를 해결했습니다.

### 🐛 해결된 문제
- FAQ 카테고리 "その他" 선택 시 React 렌더링 에러 발생
- `Objects are not valid as a React child` 에러 메시지
- 사용자가 FAQ 기능을 전혀 사용할 수 없는 치명적인 버그

### 🔧 주요 변경사항
- **백엔드 API 응답 타입 정의 추가**: `BackendCategoryResponse`, `BackendIconResponse`
- **API 데이터 변환 함수 구현**: `transformBackendCategoryResponse`
- **renderCategoryIcon 함수 개선**: 객체 타입 아이콘 처리 로직 추가
- **타입 안전성 확보**: 적절한 타입 가드 및 fallback 처리
- **백워드 호환성 유지**: 기존 코드와의 호환성 보장

### 📋 API 응답 구조 변화 대응

**변경 전 (예상):**
```typescript
{
  emojiIcon: "🕜"
}
```

**변경 후 (실제):**
```json
{
  "icon": {
    "type": "emoji",
    "value": "🕜", 
    "color": null
  }
}
```

### 🧪 Test plan
- [ ] 채팅 화면에서 학년 선택
- [ ] "その他" 버튼 클릭하여 FAQ 표시
- [ ] 아이콘이 정상적으로 렌더링되는지 확인
- [ ] 다양한 아이콘 타입 (emoji, lucide) 테스트
- [ ] 기존 FAQ 카테고리 기능 정상 작동 확인

### 🔗 Related Issues
Fixes #101

🤖 Generated with [Claude Code](https://claude.ai/code)