### PR TITLE
feat: Grade 선택지를 Attributes API로 변경

### DIFF
--- a/src/components/organisms/GradeSelection/GradeSelection.tsx
+++ b/src/components/organisms/GradeSelection/GradeSelection.tsx
@@ -3,29 +3,47 @@ import { useLocale } from '../../../contexts/LocaleContext';
 import { getColorClasses, type AccentColor } from '../../../shared/config/theme.config';
 import { getAccentColor } from '../../../shared/config/app.config';
 import { GRADE_OPTIONS, type GradeType } from '../../../shared/constants/grade.constants';
+import { AttributeItem } from '../../../types/api/attributes.types';
 
 interface GradeSelectionProps {
   onGradeSelect: (grade: GradeType) => void;
   accentColor?: AccentColor;
   className?: string;
   clientId?: string;
+  apiGrades?: AttributeItem[] | null;
+  isLoading?: boolean;
 }
 
 export const GradeSelection: React.FC<GradeSelectionProps> = ({
   onGradeSelect,
   accentColor: propAccentColor,
   className = '',
-  clientId
+  clientId,
+  apiGrades,
+  isLoading = false
 }) => {
   const { t } = useLocale();
   const defaultAccentColor = getAccentColor();
   const accentColor = propAccentColor || defaultAccentColor;
   const colors = getColorClasses(accentColor);
   
-  // MM000002일 때는 유아(preschool)를 제외
-  const filteredGrades = clientId === 'MM000002' 
-    ? GRADE_OPTIONS.filter(grade => grade.type !== 'preschool')
-    : GRADE_OPTIONS;
+  const gradeOptions = React.useMemo(() => {
+    if (apiGrades && apiGrades.length > 0) {
+      return apiGrades
+        .sort((a, b) => a.priority - b.priority)
+        .map(item => ({
+          type: item.attributeId as GradeType,
+          label: item.attributeName,
+          emoji: item.attributeIcon
+        }));
+    }
+    
+    const fallbackGrades = clientId === 'MM000002' 
+      ? GRADE_OPTIONS.filter(grade => grade.type !== 'preschool')
+      : GRADE_OPTIONS;
+    
+    return fallbackGrades;
+  }, [apiGrades, clientId]);
 
   return (
     <div
@@ -47,7 +65,18 @@ export const GradeSelection: React.FC<GradeSelectionProps> = ({
       </div>
 
       {/* Grade Options */}
-      {filteredGrades.map((grade) => (
+      {isLoading ? (
+        <div className="relative shrink-0 w-full">
+          <div className="flex flex-row items-center relative size-full">
+            <div className="box-border content-stretch flex flex-row gap-2.5 items-center justify-start pl-5 pr-0 py-0 relative w-full">
+              <div className={`${colors.textMuted} meeta-typography-mid`}>
+                読み込み中...
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : (
+        gradeOptions.map((grade) => (
         <div key={grade.type} className="relative shrink-0 w-full">
           <div className="flex flex-row items-center overflow-clip relative size-full">
             <div className="box-border content-stretch flex flex-row gap-2.5 items-center justify-start pl-5 pr-0 py-0 relative w-full">
@@ -67,7 +96,8 @@ export const GradeSelection: React.FC<GradeSelectionProps> = ({
             </div>
           </div>
         </div>
-      ))}
+        ))
+      )}
     </div>
   );
 };

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -25,6 +25,8 @@ import { GRADE_LABELS, GRADE_NAMES, type GradeType } from '../shared/constants/g
 import type { Message } from '../types';
 import { getCategories, isCategoryApiEnabled } from '../services/api/category';
 import { CategoryItem } from '../types/api/category.types';
+import { getAttributes, isAttributesApiEnabled } from '../services/api/attributes';
+import { AttributeItem } from '../types/api/attributes.types';
 
 function MainPage() {
   const { t, isLoading } = useLocale();
@@ -42,6 +44,10 @@ function MainPage() {
   // API 카테고리 관련 상태
   const [apiCategories, setApiCategories] = useState<FAQCategoryItem[] | null>(null);
   const [categoriesLoading, setCategoriesLoading] = useState(false);
+  
+  // API Attributes 관련 상태
+  const [apiGrades, setApiGrades] = useState<AttributeItem[] | null>(null);
+  const [gradesLoading, setGradesLoading] = useState(false);
   
   // 온보딩 관련 상태
   const [showGradeSelectionComponent, setShowGradeSelectionComponent] = useState(false);
@@ -135,13 +141,12 @@ function MainPage() {
       getCategories(clientId, true)
         .then(response => {
           if (response && response.items) {
-            // API 응답을 FAQCategoryItem 형식으로 변환
             const convertedCategories: FAQCategoryItem[] = response.items
               .sort((a, b) => a.displayOrder - b.displayOrder)
               .map(item => ({
                 id: item.categoryId,
-                textKey: '', // API 사용 시에는 사용하지 않음
-                valueKey: item.categoryId, // TopQuestions API에 전달할 categoryId
+                textKey: '',
+                valueKey: item.categoryId,
                 displayName: item.categoryName,
                 emojiIcon: item.icon
               }));
@@ -153,6 +158,24 @@ function MainPage() {
         })
         .finally(() => {
           setCategoriesLoading(false);
+        });
+    }
+  }, [clientId]);
+
+  useEffect(() => {
+    if (isAttributesApiEnabled() && clientId) {
+      setGradesLoading(true);
+      getAttributes(clientId, 'grade', true)
+        .then(response => {
+          if (response && response.items) {
+            setApiGrades(response.items);
+          }
+        })
+        .catch(error => {
+          console.error('Failed to load grade attributes:', error);
+        })
+        .finally(() => {
+          setGradesLoading(false);
         });
     }
   }, [clientId]);
@@ -509,6 +532,8 @@ function MainPage() {
                   <GradeSelection 
                     onGradeSelect={handleGradeSelect} 
                     clientId={clientId}
+                    apiGrades={apiGrades}
+                    isLoading={gradesLoading}
                   />
                 </div>
               )}
@@ -520,6 +545,8 @@ function MainPage() {
                   <GradeSelection 
                     onGradeSelect={handleGradeSelect}
                     clientId={clientId}
+                    apiGrades={apiGrades}
+                    isLoading={gradesLoading}
                   />
                 </div>
               )}

--- a/src/services/api/attributes.ts
+++ b/src/services/api/attributes.ts
@@ -1,0 +1,50 @@
+import { AttributesApiResponse } from '../../types/api/attributes.types';
+
+const CONTENT_CONFIG_API_URL = import.meta.env.VITE_CONTENT_CONFIG_API_URL || 'https://content-config-dev.meeta.jp/v1';
+const USE_ATTRIBUTES_API = import.meta.env.VITE_USE_ATTRIBUTES_API === 'true';
+
+export async function getAttributes(
+  clientId: string,
+  group: string = 'grade',
+  isActive: boolean = true
+): Promise<AttributesApiResponse | null> {
+  if (!USE_ATTRIBUTES_API) {
+    console.log('Attributes API is disabled');
+    return null;
+  }
+
+  try {
+    const params = new URLSearchParams({
+      clientId,
+      group,
+      isActive: isActive.toString()
+    });
+
+    const url = `${CONTENT_CONFIG_API_URL}/attributes?${params}`;
+    console.log('Fetching attributes from:', url);
+
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      }
+    });
+
+    if (!response.ok) {
+      console.error('Attributes API error:', response.status, response.statusText);
+      return null;
+    }
+
+    const data = await response.json();
+    console.log('Attributes fetched successfully:', data);
+    return data as AttributesApiResponse;
+  } catch (error) {
+    console.error('Failed to fetch attributes:', error);
+    return null;
+  }
+}
+
+export function isAttributesApiEnabled(): boolean {
+  return USE_ATTRIBUTES_API;
+}

--- a/src/types/api/attributes.types.ts
+++ b/src/types/api/attributes.types.ts
@@ -1,0 +1,30 @@
+export interface SubAttribute {
+  id: string;
+  name: string;
+}
+
+export interface AttributeItem {
+  attributeId: string;
+  attributeName: string;
+  attributeIcon: string;
+  group: string;
+  isActive: boolean;
+  priority: number;
+  subAttributes: SubAttribute[];
+  createdAt: string;
+  createdBy: string;
+  updatedAt: string;
+  updatedBy: string;
+  archivedAt: string | null;
+  archivedBy: string | null;
+}
+
+export interface AttributesApiResponse {
+  items: AttributeItem[];
+}
+
+export interface AttributesRequest {
+  clientId: string;
+  group: string;
+  isActive?: boolean;
+}


### PR DESCRIPTION
## 📋 개요
Grade 선택지를 하드코딩된 상수값에서 Attributes API를 통해 동적으로 가져오도록 변경했습니다.

Resolves #103

## 🔄 주요 변경 사항

### 초기 로딩시 API 호출 확인

<img width="1381" height="618" alt="스크린샷 2025-10-07 10 43 55" src="https://github.com/user-attachments/assets/56125f98-5f93-4998-9449-120f6d0b3a03" />


### 1. API 타입 정의 추가
- `src/types/api/attributes.types.ts` 생성
- `AttributeItem`, `AttributesApiResponse` 타입 정의

### 2. API 서비스 구현
- `src/services/api/attributes.ts` 생성
- `getAttributes()` 함수 구현
- Category API와 동일한 패턴 적용 (`VITE_CONTENT_CONFIG_API_URL` 사용)

### 3. GradeSelection 컴포넌트 수정
- API 데이터를 props로 받도록 변경
- `priority` 순서대로 정렬하여 표시
- 로딩 상태 UI 추가 ("読み込み中...")
- API 실패 시 기존 상수값으로 폴백

### 4. MainPage 수정
- Attributes API 호출 로직 추가
- `apiGrades`, `gradesLoading` 상태 관리
- GradeSelection 컴포넌트에 props 전달

## ✅ 테스트 완료
- [x] 타입체크 통과
- [x] 실제 API 연동 테스트 성공
- [x] 로딩 상태 확인
- [x] 폴백 로직 동작 확인

## 📝 환경 변수 설정 필요
`.env` 파일에 다음 설정 추가 필요:
```env
VITE_USE_ATTRIBUTES_API=true
```

🤖 Generated with [Claude Code](https://claude.ai/code)