### PR TITLE
feat: 채팅 버블 인라인 볼드 강조 표시 기능 추가

### DIFF
--- a/src/components/atoms/Typography/Typography.tsx
+++ b/src/components/atoms/Typography/Typography.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { parseTextContent } from '../../../utils/textFormatUtils';
 
 interface TypewriterTextProps {
   text: string;
@@ -15,20 +16,20 @@ export function TypewriterText({ text, speed = 50, onComplete }: TypewriterTextP
       const timer = setTimeout(() => {
         setDisplayText(prev => {
           const newText = prev + text[currentIndex];
-          
+
           // 새 글자가 추가될 때마다 스크롤
           const messageContainer = document.querySelector('.overflow-y-auto');
           if (messageContainer) {
             const scrollHeight = messageContainer.scrollHeight;
             const height = messageContainer.clientHeight;
             const maxScrollTop = scrollHeight - height;
-            
+
             messageContainer.scrollTo({
               top: maxScrollTop,
               behavior: 'smooth'
             });
           }
-          
+
           return newText;
         });
         setCurrentIndex(currentIndex + 1);
@@ -46,5 +47,5 @@ export function TypewriterText({ text, speed = 50, onComplete }: TypewriterTextP
     setCurrentIndex(0);
   }, [text]);
 
-  return <span className="whitespace-pre-wrap">{displayText}</span>;
+  return <span className="whitespace-pre-wrap">{parseTextContent(displayText)}</span>;
 }

--- a/src/components/molecules/ChatBubble/ChatBubble.tsx
+++ b/src/components/molecules/ChatBubble/ChatBubble.tsx
@@ -5,6 +5,7 @@ import { BubbleResponse, AttachmentData } from '../../../types';
 import { isIOS } from '../../../utils/device';
 import { SubBubbleContent } from './SubBubbleContent';
 import { AttachmentPreview } from './AttachmentPreview';
+import { FormattedText } from './FormattedText';
 
 interface ChatBubbleProps {
   content: string | React.ReactNode;
@@ -111,15 +112,19 @@ export function ChatBubble({
               />
             ) : (
               bubbleType === 'sub' && typeof displayContent === 'string' ? (
-                <SubBubbleContent 
-                  content={displayContent} 
+                <SubBubbleContent
+                  content={displayContent}
                   isTypingComplete={localTypingComplete}
                   attachment={attachment}
                 />
               ) : (
-                <div className="whitespace-pre-wrap">
-                  {typeof displayContent === 'string' ? displayContent : displayContent}
-                </div>
+                typeof displayContent === 'string' ? (
+                  <FormattedText content={displayContent} />
+                ) : (
+                  <div className="whitespace-pre-wrap">
+                    {displayContent}
+                  </div>
+                )
               )
             )}
           </div>
@@ -137,9 +142,13 @@ export function ChatBubble({
             <div
               className="relative text-[#303030] text-left meeta-text-mid-regular"
             >
-              <div className="whitespace-pre-wrap">
-                {typeof content === 'string' ? content : content}
-              </div>
+              {typeof content === 'string' ? (
+                <FormattedText content={content} />
+              ) : (
+                <div className="whitespace-pre-wrap">
+                  {content}
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/src/components/molecules/ChatBubble/FormattedText.tsx
+++ b/src/components/molecules/ChatBubble/FormattedText.tsx
@@ -1,0 +1,19 @@
+import { parseTextContent } from '../../../utils/textFormatUtils';
+
+interface FormattedTextProps {
+  content: string;
+  className?: string;
+}
+
+/**
+ * 텍스트 파싱 컴포넌트
+ * - **텍스트** 패턴을 볼드로 변환
+ * - URL을 링크로 변환
+ */
+export function FormattedText({ content, className }: FormattedTextProps) {
+  return (
+    <div className={`whitespace-pre-wrap ${className || ''}`}>
+      {parseTextContent(content)}
+    </div>
+  );
+}

--- a/src/components/molecules/ChatBubble/SubBubbleContent.tsx
+++ b/src/components/molecules/ChatBubble/SubBubbleContent.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { AttachmentData } from '../../../types';
+import { parseTextContent } from '../../../utils/textFormatUtils';
 
 interface SubBubbleContentProps {
   content: string;
@@ -10,66 +11,24 @@ interface SubBubbleContentProps {
 
 export function SubBubbleContent({ content, className, isTypingComplete = true, attachment }: SubBubbleContentProps) {
   // (image) 텍스트 제거
-  const processedContent = content.includes('(image)') 
+  const processedContent = content.includes('(image)')
     ? content.replace('(image)', '').trim()
     : content;
-
-  // URL을 감지하고 링크로 변환하는 함수
-  const convertUrlsToLinks = (text: string): React.ReactNode[] => {
-    // URL 패턴 정규식 (http://, https://, www. 로 시작하는 URL 감지)
-    const urlPattern = /(https?:\/\/[^\s]+)|(www\.[^\s]+)/g;
-    const parts: React.ReactNode[] = [];
-    let lastIndex = 0;
-    let match;
-
-    while ((match = urlPattern.exec(text)) !== null) {
-      // URL 이전의 일반 텍스트 추가
-      if (match.index > lastIndex) {
-        parts.push(text.substring(lastIndex, match.index));
-      }
-
-      // URL을 링크로 변환
-      const url = match[0];
-      const href = url.startsWith('http') ? url : `https://${url}`;
-      
-      parts.push(
-        <a
-          key={match.index}
-          href={href}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-blue-600 underline hover:text-blue-800 hover:no-underline"
-          onClick={(e) => e.stopPropagation()}
-        >
-          {url}
-        </a>
-      );
-
-      lastIndex = match.index + url.length;
-    }
-
-    // 마지막 남은 텍스트 추가
-    if (lastIndex < text.length) {
-      parts.push(text.substring(lastIndex));
-    }
-
-    return parts.length > 0 ? parts : [text];
-  };
 
   // attachment type에 따른 렌더링 분기
   if (attachment) {
     if (attachment.type === 'link') {
-      // link 타입: URL 변환만 수행
+      // link 타입: URL 및 볼드 변환 수행
       return (
         <div className={`whitespace-pre-wrap ${className || ''}`}>
-          {convertUrlsToLinks(processedContent)}
+          {parseTextContent(processedContent)}
         </div>
       );
     } else {
       // link가 아닌 모든 타입: 텍스트만 표시 (AttachmentPreview는 ChatBubble에서 분리 렌더링)
       return (
         <div className={`whitespace-pre-wrap ${className || ''}`}>
-          {convertUrlsToLinks(processedContent)}
+          {parseTextContent(processedContent)}
         </div>
       );
     }
@@ -78,7 +37,7 @@ export function SubBubbleContent({ content, className, isTypingComplete = true, 
   // attachment가 없는 기본 처리
   return (
     <div className={`whitespace-pre-wrap ${className || ''}`}>
-      {convertUrlsToLinks(processedContent)}
+      {parseTextContent(processedContent)}
     </div>
   );
 }

--- a/src/utils/textFormatUtils.tsx
+++ b/src/utils/textFormatUtils.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+
+/**
+ * **텍스트** 패턴을 볼드로 변환하는 함수
+ * - **가 열리면 바로 볼드 시작 (닫는 **가 없어도 끝까지 볼드 처리)
+ */
+export function parseBoldText(text: string): React.ReactNode[] {
+  const parts: React.ReactNode[] = [];
+  let currentIndex = 0;
+  let boldStartIndex = -1;
+  let keyCounter = 0;
+
+  for (let i = 0; i < text.length; i++) {
+    // **를 찾음 (2글자 연속)
+    if (i < text.length - 1 && text[i] === '*' && text[i + 1] === '*') {
+      if (boldStartIndex === -1) {
+        // 열린 ** 발견: 이전 일반 텍스트 추가
+        if (i > currentIndex) {
+          parts.push(text.substring(currentIndex, i));
+        }
+        boldStartIndex = i + 2; // ** 다음부터 볼드 시작
+        i++; // ** 두 글자를 건너뜀
+        currentIndex = i + 1;
+      } else {
+        // 닫는 ** 발견: 볼드 텍스트 추가
+        const boldText = text.substring(boldStartIndex, i);
+        parts.push(
+          <strong key={`bold-${keyCounter++}`} className="font-bold">
+            {boldText}
+          </strong>
+        );
+        boldStartIndex = -1;
+        i++; // ** 두 글자를 건너뜀
+        currentIndex = i + 1;
+      }
+    }
+  }
+
+  // 닫히지 않은 볼드가 있으면 끝까지 볼드로 처리
+  if (boldStartIndex !== -1) {
+    const boldText = text.substring(boldStartIndex);
+    parts.push(
+      <strong key={`bold-${keyCounter++}`} className="font-bold">
+        {boldText}
+      </strong>
+    );
+  } else if (currentIndex < text.length) {
+    // 남은 일반 텍스트 추가
+    parts.push(text.substring(currentIndex));
+  }
+
+  return parts.length > 0 ? parts : [text];
+}
+
+/**
+ * URL을 감지하고 링크로 변환하는 함수 (React 노드 배열 처리)
+ */
+export function convertUrlsToLinks(nodes: React.ReactNode[]): React.ReactNode[] {
+  const urlPattern = /(https?:\/\/[^\s]+)|(www\.[^\s]+)/g;
+  const result: React.ReactNode[] = [];
+
+  nodes.forEach((node, nodeIndex) => {
+    // 문자열 노드만 URL 변환 처리
+    if (typeof node === 'string') {
+      const parts: React.ReactNode[] = [];
+      let lastIndex = 0;
+      let match;
+
+      while ((match = urlPattern.exec(node)) !== null) {
+        if (match.index > lastIndex) {
+          parts.push(node.substring(lastIndex, match.index));
+        }
+
+        const url = match[0];
+        const href = url.startsWith('http') ? url : `https://${url}`;
+
+        parts.push(
+          <a
+            key={`url-${nodeIndex}-${match.index}`}
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 underline hover:text-blue-800 hover:no-underline"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {url}
+          </a>
+        );
+
+        lastIndex = match.index + url.length;
+      }
+
+      if (lastIndex < node.length) {
+        parts.push(node.substring(lastIndex));
+      }
+
+      result.push(...(parts.length > 0 ? parts : [node]));
+    } else {
+      // 문자열이 아닌 노드(예: <strong> 태그)는 그대로 유지
+      result.push(node);
+    }
+  });
+
+  return result;
+}
+
+/**
+ * 텍스트 파싱: 볼드 → URL 순서로 처리
+ */
+export function parseTextContent(text: string): React.ReactNode[] {
+  const boldParsed = parseBoldText(text);
+  return convertUrlsToLinks(boldParsed);
+}


### PR DESCRIPTION
## Summary
- 채팅 버블에서 `**텍스트**` 패턴을 실시간으로 볼드체로 렌더링하는 기능 추가
- 타이핑 효과 중에도 `**`가 입력되는 즉시 볼드 적용되도록 개선
- 텍스트 파싱 로직을 공통 유틸 함수로 리팩토링하여 재사용성 향상

## 주요 변경사항
### 1. 텍스트 파싱 유틸 추가 (`textFormatUtils.tsx`)
- `parseBoldText`: `**텍스트**` 패턴을 `<strong>` 태그로 변환
- `convertUrlsToLinks`: URL을 클릭 가능한 링크로 변환
- `parseTextContent`: 볼드 → URL 순서로 텍스트 파싱

### 2. TypewriterText 개선
- 타이핑 효과 중에도 실시간으로 볼드 처리 적용
- `**`가 열리면 즉시 볼드 시작 (닫는 `**` 없어도 처리)

### 3. FormattedText 컴포넌트 추가
- 재사용 가능한 텍스트 포맷팅 컴포넌트
- 볼드 + URL 링크 변환 기능 제공

### 4. ChatBubble 및 SubBubbleContent 개선
- 공통 파싱 유틸 함수 사용으로 코드 중복 제거
- 봇/사용자 메시지 모두 일관된 포맷팅 적용

## 동작 예시
**이전**: 타이핑 중 `**サポート体制**` → 닫는 `**`가 입력되어야 볼드 적용
**현재**: 타이핑 중 `**サ` → 즉시 **サ**로 볼드 표시

### 동작 영상

https://github.com/user-attachments/assets/515f72e8-c3ec-48cd-a863-14fef2bdd0c1


## Test plan
- [x] 빌드 성공 확인
- [x] 타이핑 효과 중 볼드 실시간 적용 확인
- [x] 완성된 메시지에서 볼드 정상 표시 확인
- [x] URL 링크 변환 기능 정상 동작 확인


🤖 Generated with [Claude Code](https://claude.com/claude-code)