### PR TITLE
feat: 내부생(APP001) 전용 그리팅 메시지 구현

### DIFF
--- a/docs/WIP/MEETA-263-inbound-greeting-message.md
+++ b/docs/WIP/MEETA-263-inbound-greeting-message.md
@@ -1,0 +1,116 @@
+# MEETA-263: 내부생(APP001) 전용 그리팅 메시지 구현
+
+## 개요
+APP001(내부생) 접속 시 그리팅 메시지를 변경하여 "お子様" 대신 "あなた"를 사용하도록 수정
+
+## 완료된 수정 사항
+
+### 1. isInboundApp 유틸리티 함수 추가
+**파일**: `src/utils/appFeatures.ts`
+
+```typescript
+/**
+ * 내부생(Inbound) 앱 여부를 확인하는 함수
+ * @param appId - 애플리케이션 ID
+ * @returns 내부생 앱이면 true, 아니면 false
+ */
+export const isInboundApp = (appId: string): boolean => {
+  return appId === 'APP001';
+};
+```
+
+### 2. isFAQEnabled 함수 리팩토링
+**파일**: `src/utils/appFeatures.ts`
+
+```typescript
+export const isFAQEnabled = (appId: string): boolean => {
+  // 내부생 앱의 경우 FAQ 기능 비활성화
+  return !isInboundApp(appId);
+};
+```
+
+### 3. GradeQuickReply.tsx 수정
+**파일**: `src/components/organisms/GradeQuickReply/GradeQuickReply.tsx`
+
+- import에 `isInboundApp` 추가
+- `appId === 'APP001'` → `isInboundApp(appId || '')`로 변경
+
+### 4. QuickReply.tsx 수정
+**파일**: `src/components/organisms/QuickReply/QuickReply.tsx`
+
+- import에 `isInboundApp` 추가
+- `appId === 'APP001'` → `isInboundApp(appId || '')`로 변경
+
+### 5. 로케일 파일 수정
+
+**일본어** (`src/locales/ja/common.json`)
+```json
+"onboarding": {
+  "gradeSelectionHeader": "お子様の学年を教えてください",
+  "gradeSelectionMessage": "まずは、お子様の学年を教えてください🙋",
+  "gradeSelectionMessageForInbound": "まずは、あなたの学年を教えてください🙋"
+}
+```
+
+**영어** (`src/locales/en/common.json`)
+```json
+"onboarding": {
+  "gradeSelectionHeader": "Please tell us your child's grade level",
+  "gradeSelectionMessage": "First, please tell us your child's grade level🙋",
+  "gradeSelectionMessageForInbound": "First, please tell us your grade level🙋"
+}
+```
+
+**한국어** (`src/locales/ko/common.json`)
+```json
+"onboarding": {
+  "gradeSelectionHeader": "자녀의 학년을 알려주세요",
+  "gradeSelectionMessage": "먼저, 자녀의 학년을 알려주세요🙋",
+  "gradeSelectionMessageForInbound": "먼저, 본인의 학년을 알려주세요🙋"
+}
+```
+
+### 6. MainPage.tsx 수정
+**파일**: `src/pages/MainPage.tsx`
+
+```typescript
+// import 추가
+import { isFAQEnabled, isInboundApp } from '../utils/appFeatures';
+
+// 그리팅 메시지 로직
+useEffect(() => {
+  if (showOnboardingMessage) {
+    // 내부생 앱의 경우 다른 메시지 사용
+    const messageKey = isInboundApp(appId)
+      ? 'onboarding.gradeSelectionMessageForInbound'
+      : 'onboarding.gradeSelectionMessage';
+    const onboardingMessage = t(messageKey);
+    addTypingBotMessage(onboardingMessage);
+    // ...
+  }
+}, [showOnboardingMessage, addTypingBotMessage, t, appId]);
+```
+
+## 수정 파일 요약
+
+| 파일 | 수정 내용 |
+|------|----------|
+| `src/utils/appFeatures.ts` | `isInboundApp()` 함수 추가, `isFAQEnabled()` 리팩토링 |
+| `src/locales/ja/common.json` | `gradeSelectionMessageForInbound` 키 추가 |
+| `src/locales/en/common.json` | `gradeSelectionMessageForInbound` 키 추가 |
+| `src/locales/ko/common.json` | `gradeSelectionMessageForInbound` 키 추가 |
+| `src/components/organisms/GradeQuickReply/GradeQuickReply.tsx` | `isInboundApp` 사용 |
+| `src/components/organisms/QuickReply/QuickReply.tsx` | `isInboundApp` 사용 |
+| `src/pages/MainPage.tsx` | 그리팅 메시지 분기 처리 |
+
+## 테스트 확인 사항
+
+1. APP001로 접속 시 "まずは、あなたの学年を教えてください🙋" 표시
+2. 다른 appId로 접속 시 기존 메시지 "まずは、お子様の学年を教えてください🙋" 표시
+3. 기존 기능(FAQ 비활성화, QuickReply/GradeQuickReply 비표시)이 정상 동작
+
+## 관련 티켓
+- MEETA-263
+
+## 빌드 상태
+- ✅ 빌드 성공 (npm run build)

--- a/src/components/organisms/GradeQuickReply/GradeQuickReply.tsx
+++ b/src/components/organisms/GradeQuickReply/GradeQuickReply.tsx
@@ -3,7 +3,7 @@ import { useLocale } from '../../../contexts/LocaleContext';
 import { QuickReply, type QuickReplyOption } from '../QuickReply';
 import { GRADE_QUESTION_KEYS, type GradeType } from '../../../shared/constants/grade.constants';
 import { isFaqApiEnabled } from '../../../services/api/faq';
-import { isFAQEnabled } from '../../../utils/appFeatures';
+import { isFAQEnabled, isInboundApp } from '../../../utils/appFeatures';
 
 interface GradeQuickReplyProps {
   grade: GradeType;
@@ -51,8 +51,8 @@ export const GradeQuickReply: React.FC<GradeQuickReplyProps> = ({
     ] : baseOptions;
   }
 
-  // APP001의 경우 GradeQuickReply 자체를 렌더링하지 않음
-  if (appId === 'APP001') {
+  // 내부생 앱의 경우 GradeQuickReply 자체를 렌더링하지 않음
+  if (isInboundApp(appId || '')) {
     return null;
   }
 

--- a/src/components/organisms/QuickReply/QuickReply.tsx
+++ b/src/components/organisms/QuickReply/QuickReply.tsx
@@ -7,7 +7,7 @@ import { getQuickReplyQuestions, updateQuestionStats, type QuickReplyData } from
 import { getQuickReplyQuestions as getQuickReplyQuestionsAPI, isFaqApiEnabled } from '../../../services/api/faq';
 import { Button } from '../../atoms/Button';
 import type { GradeType } from '../../../shared/constants/grade.constants';
-import { isFAQEnabled } from '../../../utils/appFeatures';
+import { isFAQEnabled, isInboundApp } from '../../../utils/appFeatures';
 
 export interface QuickReplyOption {
   id: string;
@@ -120,8 +120,8 @@ export function QuickReply({
     }
   }, [show, userId, options, t, grade]);
 
-  // APP001의 경우 QuickReply 자체를 렌더링하지 않음
-  if (!show || appId === 'APP001') return null;
+  // 내부생 앱의 경우 QuickReply 자체를 렌더링하지 않음
+  if (!show || isInboundApp(appId || '')) return null;
 
   const handleOptionClick = async (option: QuickReplyOption) => {
     // "그외" 버튼의 경우 FAQ 카테고리 표시 (FAQ가 활성화된 경우에만)

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -13,7 +13,8 @@
   },
   "onboarding": {
     "gradeSelectionHeader": "Please tell us your child's grade level",
-    "gradeSelectionMessage": "First, please tell us your child's grade level🙋"
+    "gradeSelectionMessage": "First, please tell us your child's grade level🙋",
+    "gradeSelectionMessageForInbound": "First, please tell us your grade level🙋"
   },
   "student": {
     "menu": {

--- a/src/locales/ja/common.json
+++ b/src/locales/ja/common.json
@@ -13,7 +13,8 @@
   },
   "onboarding": {
     "gradeSelectionHeader": "お子様の学年を教えてください",
-    "gradeSelectionMessage": "まずは、お子様の学年を教えてください🙋"
+    "gradeSelectionMessage": "まずは、お子様の学年を教えてください🙋",
+    "gradeSelectionMessageForInbound": "まずは、あなたの学年を教えてください🙋"
   },
   "student": {
     "menu": {

--- a/src/locales/ko/common.json
+++ b/src/locales/ko/common.json
@@ -13,7 +13,8 @@
   },
   "onboarding": {
     "gradeSelectionHeader": "자녀의 학년을 알려주세요",
-    "gradeSelectionMessage": "먼저, 자녀의 학년을 알려주세요🙋"
+    "gradeSelectionMessage": "먼저, 자녀의 학년을 알려주세요🙋",
+    "gradeSelectionMessageForInbound": "먼저, 본인의 학년을 알려주세요🙋"
   },
   "student": {
     "menu": {

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -27,7 +27,7 @@ import { getCategories, isCategoryApiEnabled } from '../services/api/category';
 import { CategoryItem } from '../types/api/category.types';
 import { getAttributes, isAttributesApiEnabled } from '../services/api/attributes';
 import { AttributeItem } from '../types/api/attributes.types';
-import { isFAQEnabled } from '../utils/appFeatures';
+import { isFAQEnabled, isInboundApp } from '../utils/appFeatures';
 
 function MainPage() {
   const { t, isLoading } = useLocale();
@@ -208,10 +208,13 @@ function MainPage() {
   // 온보딩 메시지가 표시된 후 GradeSelection 표시
   useEffect(() => {
     if (showOnboardingMessage) {
-      // 온보딩 메시지를 ChatMessage로 추가
-      const onboardingMessage = t('onboarding.gradeSelectionMessage');
+      // 내부생 앱의 경우 다른 메시지 사용
+      const messageKey = isInboundApp(appId)
+        ? 'onboarding.gradeSelectionMessageForInbound'
+        : 'onboarding.gradeSelectionMessage';
+      const onboardingMessage = t(messageKey);
       addTypingBotMessage(onboardingMessage);
-      
+
       setTimeout(() => {
         setShowGradeSelectionComponent(true);
         setTimeout(() => {
@@ -219,7 +222,7 @@ function MainPage() {
         }, 100);
       }, 1000);
     }
-  }, [showOnboardingMessage, addTypingBotMessage, t]);
+  }, [showOnboardingMessage, addTypingBotMessage, t, appId]);
 
   // 학년 선택 핸들러
   const handleGradeSelect = (grade: GradeType) => {

--- a/src/utils/appFeatures.ts
+++ b/src/utils/appFeatures.ts
@@ -3,13 +3,22 @@
  */
 
 /**
+ * 내부생(Inbound) 앱 여부를 확인하는 함수
+ * @param appId - 애플리케이션 ID
+ * @returns 내부생 앱이면 true, 아니면 false
+ */
+export const isInboundApp = (appId: string): boolean => {
+  return appId === 'APP001';
+};
+
+/**
  * FAQ 기능 활성화 여부를 확인하는 함수
  * @param appId - 애플리케이션 ID
  * @returns FAQ 기능이 활성화되어 있으면 true, 비활성화되어 있으면 false
  */
 export const isFAQEnabled = (appId: string): boolean => {
-  // APP001의 경우 FAQ 기능 비활성화
-  return appId !== 'APP001';
+  // 내부생 앱의 경우 FAQ 기능 비활성화
+  return !isInboundApp(appId);
 };
 
 /**


### PR DESCRIPTION
## 요약
- 내부생(APP001) 접속 시 그리팅 메시지를 "お子様" 대신 "あなた"로 변경
- APP001 판별 로직을 `isInboundApp` 유틸리티 함수로 통합하여 일관성 확보

## 변경 사항

### 1. isInboundApp 유틸리티 함수 추가
- `src/utils/appFeatures.ts`에 `isInboundApp(appId)` 함수 추가
- APP001 여부를 판별하는 중앙화된 함수

### 2. 기존 코드 리팩토링
- `isFAQEnabled`: `isInboundApp` 사용하도록 변경
- `GradeQuickReply.tsx`: 직접 비교 대신 `isInboundApp` 사용
- `QuickReply.tsx`: 직접 비교 대신 `isInboundApp` 사용

### 3. 로케일 파일 수정 (ja/en/ko)
- `gradeSelectionMessageForInbound` 키 추가
- 일본어: `まずは、あなたの学年を教えてください🙋`

### 4. MainPage.tsx 그리팅 메시지 분기 처리
- `isInboundApp(appId)` 결과에 따라 메시지 키 선택

## 테스트 계획
- [x] APP001로 접속 시 "まずは、あなたの学年を教えてください🙋" 표시 확인
- [x] 다른 appId로 접속 시 기존 메시지 표시 확인
- [x] 기존 기능(FAQ 비활성화 등) 정상 동작 확인

## 관련 티켓
- MEETA-263

🤖 Generated with [Claude Code](https://claude.com/claude-code)