### PR TITLE
feat: 내부생(APP001) 앱에서 CTA 버튼 비활성화

### DIFF
--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -528,9 +528,9 @@ function MainPage() {
                   hideAvatar={message.type === 'bot' && !isFirstBotMessage}
                   llmResponse={message.llmResponse}
                   clientId={clientId}
-                  // 최신 LLM 응답에서만 CTA 버튼 표시
+                  // 최신 LLM 응답에서만 CTA 버튼 표시 (내부생 앱에서는 표시하지 않음)
                   {...(message.llmResponse ? {
-                    showCTAAfterComplete: message.id === latestCTAMessageId && !hideAllCTA,
+                    showCTAAfterComplete: message.id === latestCTAMessageId && !hideAllCTA && !isInboundApp(appId),
                     onMainCTAClick: handleMainCTAClick,
                     onSubCTAClick: handleSubCTAClick,
                     onCTADisplayed: handleCTADisplayed


### PR DESCRIPTION
## 요약
- 내부생 앱(APP001)에서 자료청구/추가질문 CTA 버튼이 표시되지 않도록 수정

## 동작 확인

### 외부생

<img width="339" height="646" alt="스크린샷 2026-01-03 10 04 47" src="https://github.com/user-attachments/assets/08ddd468-31a8-43bd-8208-6b01ffd932a3" />

### 내부생

<img width="356" height="457" alt="스크린샷 2026-01-03 09 58 24" src="https://github.com/user-attachments/assets/661261cf-e1a3-4ef2-9543-9392e2344e87" />


## 변경 사항
- `MainPage.tsx`에서 CTA 버튼 표시 조건에 `!isInboundApp(appId)` 조건 추가
- 내부생(APP001) 사용자에게는 "資料請求する", "もう少し質問する" 버튼이 표시되지 않음

## 테스트 계획
- [x] 일반 앱에서 CTA 버튼이 정상적으로 표시되는지 확인
- [x] 내부생 앱(APP001)에서 CTA 버튼이 표시되지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)