### PR TITLE
feat: 채팅 API 요청 시 s3Uri를 fileInfo 객체로 변경

### DIFF
--- a/src/components/molecules/InputField/InputField.tsx
+++ b/src/components/molecules/InputField/InputField.tsx
@@ -11,6 +11,7 @@ export interface AttachedFile {
   loading?: boolean;
   fileId?: string;
   s3Key?: string;
+  s3Uri?: string;
   previewUrl?: string;
 }
 

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -5,6 +5,7 @@ import { getColorClasses } from '../shared/config/theme.config';
 import { getAccentColor } from "../shared/config/app.config";
 import { isIOS } from '../utils/device';
 import type { Message, LLMResponse } from '../types';
+import type { FileInfo } from '../types/api/fileUpload.types';
 
 interface UseChatOptions {
   userId: string;
@@ -93,9 +94,9 @@ export function useChat({ userId, gradeId, clientId, appId, onError, onTypingCom
     }
   }, [currentlyTyping]);
 
-  const sendMessage = async (messageContent?: string, s3Uri?: string): Promise<ProcessedChatResponse> => {
+  const sendMessage = async (messageContent?: string, fileInfo?: FileInfo): Promise<ProcessedChatResponse> => {
     try {
-      const response = await sendChatMessage(messageContent || newMessage, userId, gradeId, clientId, appId, s3Uri);
+      const response = await sendChatMessage(messageContent || newMessage, userId, gradeId, clientId, appId, fileInfo);
       return {
         message: response.response,
         toolName: response.tool?.name,
@@ -111,7 +112,7 @@ export function useChat({ userId, gradeId, clientId, appId, onError, onTypingCom
     }
   };
 
-  const handleSendMessage = async (messageContent?: string, imageUrl?: string, s3Uri?: string, onMessageSent?: () => void) => {
+  const handleSendMessage = async (messageContent?: string, imageUrl?: string, fileInfo?: FileInfo, onMessageSent?: () => void) => {
     const content = messageContent || newMessage;
     if (!content.trim() || isTyping) return;
 
@@ -121,7 +122,7 @@ export function useChat({ userId, gradeId, clientId, appId, onError, onTypingCom
       content: content.trim(),
       timestamp: new Date(),
       ...(imageUrl && { imageUrl }),
-      ...(s3Uri && { s3Uri })
+      ...(fileInfo && { s3Uri: fileInfo.s3Uri })
     };
 
     setMessages(prev => [...prev, userMessage]);
@@ -135,7 +136,7 @@ export function useChat({ userId, gradeId, clientId, appId, onError, onTypingCom
     setIsTyping(true);
 
     try {
-      const response = await sendMessage(content, s3Uri);
+      const response = await sendMessage(content, fileInfo);
 
       setCurrentlyTyping({
         message: response.message,

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -16,6 +16,7 @@ import { isIOS } from '../utils/device';
 import { TypingIndicator } from '../components/molecules/TypingIndicator';
 import { IOSViewportDebug } from '../components/molecules/IOSViewportDebug';
 import { AttachedFile } from '../components/molecules/InputField';
+import { FileInfo } from '../types/api/fileUpload.types';
 import { useChat } from '../hooks/useChat';
 import { useActiveComponents } from '../hooks/useActiveComponents';
 import { getAccentColor, getShowNavigationHeader, getShowGradeSelection } from '../shared/config/app.config';
@@ -347,9 +348,18 @@ function MainPage() {
     // 첨부된 파일이 있고 업로드가 완료된 경우
     if (attachedFile && !attachedFile.loading) {
       const imageUrl = attachedFile.previewUrl || attachedFile.preview;
-      const s3Uri = attachedFile.s3Uri;
+      // FileInfo 객체 구성
+      const fileInfo: FileInfo | undefined = attachedFile.fileId && attachedFile.s3Key && attachedFile.s3Uri && attachedFile.previewUrl
+        ? {
+            fileId: attachedFile.fileId,
+            fileName: attachedFile.file.name,
+            s3Key: attachedFile.s3Key,
+            s3Uri: attachedFile.s3Uri,
+            previewUrl: attachedFile.previewUrl
+          }
+        : undefined;
 
-      await handleSendMessage(undefined, imageUrl, s3Uri, () => {
+      await handleSendMessage(undefined, imageUrl, fileInfo, () => {
         // 메시지 입력창 초기화와 동일한 타이밍에 첨부 파일 삭제
         setAttachedFile(null);
       });

--- a/src/services/api/chat.ts
+++ b/src/services/api/chat.ts
@@ -1,6 +1,7 @@
 import { fetchApi } from './index';
 import { chatJWEService } from '../jwe/chatJWEService';
 import { LLMResponse } from '../../types';
+import { FileInfo } from '../../types/api/fileUpload.types';
 
 export interface ChatMessage {
   id: string;
@@ -35,7 +36,7 @@ export const sendChatMessage = async (
   gradeId?: string,
   clientId?: string,
   appId?: string,
-  s3Uri?: string
+  fileInfo?: FileInfo
 ): Promise<ExtendedChatResponse> => {
   try {
     // JWE 토큰 생성 (client_id, app_id 암호화) - 파라미터로 받은 clientId, appId 사용
@@ -76,7 +77,7 @@ export const sendChatMessage = async (
         userId,
         message,
         env, // APP_ENV 값 추가
-        ...(s3Uri && { fileUrl: s3Uri }), // s3Uri가 있으면 fileUrl로 포함
+        ...(fileInfo && { fileInfo }), // fileInfo가 있으면 포함
       }),
     });
 


### PR DESCRIPTION
## Summary
- 채팅 API 요청 시 단순 `s3Uri` 문자열 대신 `FileInfo` 객체 전체를 전달하도록 변경
- 파일 업로드 관련 정보(fileId, fileName, s3Key, s3Uri, previewUrl)를 구조화하여 API로 전송
- `AttachedFile` 인터페이스에 `s3Uri` 필드 추가

## Changes
- `InputField.tsx`: `AttachedFile` 인터페이스에 `s3Uri` 필드 추가
- `useChat.ts`: `sendMessage`, `handleSendMessage` 함수의 파라미터를 `s3Uri`에서 `FileInfo`로 변경
- `MainPage.tsx`: `FileInfo` 객체를 구성하여 `handleSendMessage`에 전달
- `chat.ts`: API 요청 body에서 `fileUrl: s3Uri` 대신 `fileInfo` 객체 전체를 전달

## Test plan
- [ ] 이미지 첨부 후 채팅 전송 시 API 요청에 fileInfo 객체가 포함되는지 확인
- [ ] 이미지 없이 일반 메시지 전송 시 정상 동작 확인
- [ ] 업로드 완료 전 전송 시도 시 정상 처리 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)